### PR TITLE
Enhance documentation with setup guide and API policy updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Gradle build output
 /build/
 /bin/*
+!/bin/bootstrap-local.sh
 !/bin/github-ci-pack-verify.sh
+!/bin/self-serve-doctor.sh
 .gradle/
 **/build/
 **/.gradle/

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -75,7 +75,7 @@
         },
         {
           "name": "MCP_SERVER_TOOLS_SURFACE",
-          "description": "Tool surface to expose. Use guided for the safer default workflow, or expert when clients need raw ZAP tools such as zap_report_read.",
+          "description": "Tool surface to expose. Use guided for the safer default workflow, including report readback. Use expert only when clients need raw ZAP tools outside the guided surface.",
           "default": "guided"
         },
         {
@@ -159,7 +159,7 @@
         },
         {
           "name": "MCP_SERVER_TOOLS_SURFACE",
-          "description": "Tool surface to expose. Use guided for the safer default workflow, or expert when clients need raw ZAP tools such as zap_report_read.",
+          "description": "Tool surface to expose. Use guided for the safer default workflow, including report readback. Use expert only when clients need raw ZAP tools outside the guided surface.",
           "default": "guided"
         },
         {

--- a/README.md
+++ b/README.md
@@ -46,24 +46,34 @@ Prerequisites:
 git clone https://github.com/dtkmn/mcp-zap-server.git
 cd mcp-zap-server
 
-cp .env.example .env
-
-# Generate values for ZAP_API_KEY and MCP_API_KEY, then put them in .env.
-openssl rand -hex 32
-openssl rand -hex 32
-
-docker compose up -d
+./bin/bootstrap-local.sh
+./dev.sh
+./bin/self-serve-doctor.sh
 ```
+
+Those scripts are the supported local happy path, not hidden magic:
+
+- `bootstrap-local.sh` creates `.env`, generates local API keys, and prepares the ZAP workspace.
+- `dev.sh` starts the Docker Compose stack with the faster JVM image.
+- `self-serve-doctor.sh` checks Docker, auth, MCP initialize, `tools/list`, guided tools, and a harmless tool call.
 
 Then open:
 
 - Open WebUI: `http://localhost:3000`
 - MCP endpoint for host-side clients: `http://localhost:7456/mcp`
+- Cursor config example: [`examples/cursor/mcp.json`](./examples/cursor/mcp.json)
+
+When scanning the bundled demo targets, use the container URLs that ZAP can
+reach from inside Compose:
+
+- Juice Shop scan target: `http://juice-shop:3000`
+- Petstore scan target: `http://petstore:8080`
 
 The default Compose stack publishes host ports on `127.0.0.1` only. Set `MCP_ZAP_BIND_ADDRESS=0.0.0.0` only when you intentionally expose the stack behind trusted network controls.
 
 Client setup:
 
+- [Self-Serve First Run](https://danieltse.org/mcp-zap-server/getting-started/self-serve-first-run/)
 - [Authentication Quick Start](https://danieltse.org/mcp-zap-server/getting-started/authentication-quick-start/)
 - [MCP Client Configuration](https://danieltse.org/mcp-zap-server/getting-started/mcp-client-authentication/)
 - [Tool Surfaces](https://danieltse.org/mcp-zap-server/getting-started/tool-surfaces/)
@@ -165,6 +175,7 @@ become product claims.
 Start here:
 
 - [Full documentation](https://danieltse.org/mcp-zap-server/)
+- [Self-Serve First Run](https://danieltse.org/mcp-zap-server/getting-started/self-serve-first-run/)
 - [OSS Extension Model](./docs/extensions/README.md)
 - [Authentication Quick Start](https://danieltse.org/mcp-zap-server/getting-started/authentication-quick-start/)
 - [MCP Client Authentication](https://danieltse.org/mcp-zap-server/getting-started/mcp-client-authentication/)

--- a/bin/bootstrap-local.sh
+++ b/bin/bootstrap-local.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENV_EXAMPLE="${REPO_ROOT}/.env.example"
+ENV_FILE="${REPO_ROOT}/.env"
+WORKSPACE_DIR="${REPO_ROOT}/zap-workplace"
+FORCE=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./bin/bootstrap-local.sh [--force] [--workspace /absolute/path]
+
+Creates a local .env for the Docker Compose quick start by:
+- generating secure ZAP and MCP API keys
+- setting the workspace path
+- keeping MCP auth in api-key mode
+- disabling JWT by default
+- enabling localhost/private-network scanning for bundled local demo targets
+- creating the workspace directories used by ZAP
+EOF
+}
+
+replace_or_append() {
+  local key="$1"
+  local value="$2"
+  local file="$3"
+  local tmp
+
+  tmp="$(mktemp)"
+  awk -v k="$key" -v v="$value" '
+    $0 ~ "^" k "=" {
+      print k "=" v
+      found=1
+      next
+    }
+    { print }
+    END {
+      if (!found) {
+        print k "=" v
+      }
+    }
+  ' "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --workspace)
+      if [[ $# -lt 2 ]]; then
+        echo "--workspace requires a path" >&2
+        exit 1
+      fi
+      WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_command openssl
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "Could not find $ENV_EXAMPLE" >&2
+  exit 1
+fi
+
+if [[ -f "$ENV_FILE" && "$FORCE" -ne 1 ]]; then
+  echo ".env already exists at ${ENV_FILE}" >&2
+  echo "Re-run with --force to overwrite it." >&2
+  exit 1
+fi
+
+mkdir -p "${WORKSPACE_DIR}/zap-wrk" "${WORKSPACE_DIR}/zap-home"
+
+cp "$ENV_EXAMPLE" "$ENV_FILE"
+
+replace_or_append "ZAP_API_KEY" "$(openssl rand -hex 32)" "$ENV_FILE"
+replace_or_append "MCP_API_KEY" "$(openssl rand -hex 32)" "$ENV_FILE"
+replace_or_append "LOCAL_ZAP_WORKPLACE_FOLDER" "$WORKSPACE_DIR" "$ENV_FILE"
+replace_or_append "MCP_SECURITY_MODE" "api-key" "$ENV_FILE"
+replace_or_append "MCP_SECURITY_ENABLED" "true" "$ENV_FILE"
+replace_or_append "MCP_SECURITY_ALLOW_PLACEHOLDER_API_KEY" "false" "$ENV_FILE"
+replace_or_append "JWT_ENABLED" "false" "$ENV_FILE"
+replace_or_append "ZAP_ALLOW_LOCALHOST" "true" "$ENV_FILE"
+replace_or_append "ZAP_ALLOW_PRIVATE_NETWORKS" "true" "$ENV_FILE"
+
+cat <<EOF
+Local quick-start environment created:
+- .env: ${ENV_FILE}
+- workspace: ${WORKSPACE_DIR}
+
+Generated values:
+- ZAP_API_KEY
+- MCP_API_KEY
+
+Local demo behavior:
+- MCP auth mode: api-key
+- JWT: disabled
+- localhost/private-network scanning: enabled for bundled local targets
+
+Next steps:
+1. Start the default self-serve stack with ./dev.sh
+2. Run ./bin/self-serve-doctor.sh to verify the API-key MCP path
+3. Open the bundled browser client at http://localhost:3000, or connect Cursor with examples/cursor/mcp.json
+EOF

--- a/bin/self-serve-doctor.sh
+++ b/bin/self-serve-doctor.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ENV_FILE="${REPO_ROOT}/.env"
+SERVER_URL="http://localhost:7456/mcp"
+HEALTH_URL="http://localhost:7456/actuator/health"
+ZAP_URL="http://localhost:8090/"
+OPEN_WEBUI_HEALTH_URL="http://localhost:3000/health"
+MCP_API_KEY="${MCP_API_KEY:-}"
+MCP_PROTOCOL_VERSION="${MCP_PROTOCOL_VERSION:-2025-11-25}"
+SKIP_DOCKER=0
+SKIP_TOOL_CALL=0
+SKIP_ZAP=0
+
+FAILURES=()
+
+usage() {
+  cat <<'EOF'
+Usage: ./bin/self-serve-doctor.sh [options]
+
+Checks the local self-serve API-key path end-to-end:
+- local .env / API key presence
+- Docker and Compose availability
+- MCP and ZAP reachability
+- MCP initialize + tools/list
+- guided scan, report, and evidence tool visibility
+- one harmless tool call (zap_passive_scan_status)
+
+Options:
+  --env-file PATH      Read MCP_API_KEY from a different env file.
+  --api-key VALUE      Override MCP_API_KEY instead of reading it from env.
+  --server-url URL     MCP endpoint URL. Default: http://localhost:7456/mcp
+  --health-url URL     MCP health URL. Default: http://localhost:7456/actuator/health
+  --zap-url URL        ZAP URL to probe. Default: http://localhost:8090/
+  --protocol-version VERSION
+                       MCP protocol version to negotiate. Default: 2025-11-25.
+  --skip-docker        Skip Docker/Compose and local service checks.
+  --skip-zap           Skip the ZAP reachability probe.
+  --skip-tool-call     Skip the harmless zap_passive_scan_status probe.
+  --help, -h           Show this help message.
+EOF
+}
+
+pass() {
+  printf 'PASS %s\n' "$1"
+}
+
+note() {
+  printf 'NOTE %s\n' "$1"
+}
+
+fail() {
+  printf 'FAIL %s\n' "$1" >&2
+  FAILURES+=("$1")
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    fail "Missing required command: $1"
+    return 1
+  fi
+}
+
+require_tool_in_list() {
+  local tool="$1"
+  local body_file="$2"
+
+  if grep -Eq "\"name\"[[:space:]]*:[[:space:]]*\"${tool}\"" "${body_file}"; then
+    pass "Guided tool available: ${tool}"
+  else
+    fail "Guided tool missing from tools/list: ${tool}"
+  fi
+}
+
+trim_quotes() {
+  local value="$1"
+  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  printf '%s' "${value}"
+}
+
+read_env_value() {
+  local key="$1"
+  local file="$2"
+  local value
+
+  if [[ ! -f "${file}" ]]; then
+    return 1
+  fi
+
+  value="$(sed -n "s/^${key}=//p" "${file}" | tail -n 1)"
+  if [[ -z "${value}" ]]; then
+    return 1
+  fi
+
+  trim_quotes "${value}"
+}
+
+post_json() {
+  local url="$1"
+  local payload="$2"
+  local headers_file="$3"
+  local body_file="$4"
+  shift 4
+  local -a args
+
+  args=(
+    curl
+    -sS
+    -D "${headers_file}"
+    -o "${body_file}"
+    -w "%{http_code}"
+    -H "Accept: application/json,text/event-stream"
+    -H "Content-Type: application/json"
+  )
+
+  while [[ $# -gt 0 ]]; do
+    args+=(-H "$1")
+    shift
+  done
+
+  args+=("${url}" -d "${payload}")
+  "${args[@]}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      if [[ $# -lt 2 ]]; then
+        echo "--env-file requires a value" >&2
+        exit 1
+      fi
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --api-key)
+      if [[ $# -lt 2 ]]; then
+        echo "--api-key requires a value" >&2
+        exit 1
+      fi
+      MCP_API_KEY="$2"
+      shift 2
+      ;;
+    --server-url)
+      if [[ $# -lt 2 ]]; then
+        echo "--server-url requires a value" >&2
+        exit 1
+      fi
+      SERVER_URL="$2"
+      shift 2
+      ;;
+    --health-url)
+      if [[ $# -lt 2 ]]; then
+        echo "--health-url requires a value" >&2
+        exit 1
+      fi
+      HEALTH_URL="$2"
+      shift 2
+      ;;
+    --zap-url)
+      if [[ $# -lt 2 ]]; then
+        echo "--zap-url requires a value" >&2
+        exit 1
+      fi
+      ZAP_URL="$2"
+      shift 2
+      ;;
+    --protocol-version)
+      if [[ $# -lt 2 ]]; then
+        echo "--protocol-version requires a value" >&2
+        exit 1
+      fi
+      MCP_PROTOCOL_VERSION="$2"
+      shift 2
+      ;;
+    --skip-docker)
+      SKIP_DOCKER=1
+      shift
+      ;;
+    --skip-zap)
+      SKIP_ZAP=1
+      shift
+      ;;
+    --skip-tool-call)
+      SKIP_TOOL_CALL=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_command curl || true
+require_command awk || true
+require_command sed || true
+require_command grep || true
+
+if [[ "${SKIP_DOCKER}" -eq 0 ]]; then
+  require_command docker || true
+fi
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  printf '\nDoctor could not run because required commands are missing.\n' >&2
+  exit 1
+fi
+
+if [[ -z "${MCP_API_KEY}" ]]; then
+  if [[ -f "${ENV_FILE}" ]]; then
+    MCP_API_KEY="$(read_env_value "MCP_API_KEY" "${ENV_FILE}" || true)"
+  fi
+fi
+
+if [[ -f "${ENV_FILE}" ]]; then
+  pass "Environment file found at ${ENV_FILE}"
+else
+  fail "Missing ${ENV_FILE}. Run ./bin/bootstrap-local.sh first."
+fi
+
+if [[ -n "${MCP_API_KEY}" ]]; then
+  pass "MCP_API_KEY is available for the self-serve API-key path"
+else
+  fail "MCP_API_KEY is missing. Set it in ${ENV_FILE} or pass --api-key."
+fi
+
+if [[ "${SKIP_DOCKER}" -eq 0 ]]; then
+  if docker info >/dev/null 2>&1; then
+    pass "Docker daemon is reachable"
+  else
+    fail "Docker daemon is not available. Start Docker and retry."
+  fi
+
+  if docker compose version >/dev/null 2>&1; then
+    pass "docker compose is available"
+  else
+    fail "docker compose is not available."
+  fi
+
+  if [[ ${#FAILURES[@]} -eq 0 ]]; then
+    running_services="$(docker compose ps --services --status running 2>/dev/null || true)"
+    if grep -qx 'mcp-server' <<<"${running_services}"; then
+      pass "Local mcp-server container is running"
+    else
+      fail "Local mcp-server container is not running. Start it with ./dev.sh."
+    fi
+
+    if grep -qx 'zap' <<<"${running_services}"; then
+      pass "Local zap container is running"
+    else
+      fail "Local zap container is not running. Start it with ./dev.sh."
+    fi
+
+    if grep -qx 'open-webui' <<<"${running_services}"; then
+      if curl -fsS "${OPEN_WEBUI_HEALTH_URL}" >/dev/null 2>&1; then
+        pass "Open WebUI container is running"
+      else
+        note "Open WebUI container is running but its health endpoint is not ready yet"
+      fi
+    else
+      note "Open WebUI is not running. The default Compose stack normally includes it for the bundled browser client."
+    fi
+  fi
+fi
+
+mcp_reachable=0
+if curl -fsS "${HEALTH_URL}" | grep -q '"status":"UP"'; then
+  pass "MCP health endpoint is UP at ${HEALTH_URL}"
+  mcp_reachable=1
+else
+  fail "MCP health endpoint is not ready at ${HEALTH_URL}. Start the stack with ./dev.sh."
+fi
+
+if [[ "${SKIP_ZAP}" -eq 0 ]]; then
+  if curl -fsS "${ZAP_URL}" >/dev/null 2>&1; then
+    pass "ZAP is reachable at ${ZAP_URL}"
+  else
+    fail "ZAP is not reachable at ${ZAP_URL}."
+  fi
+fi
+
+session_id=""
+negotiated_protocol_version=""
+if [[ "${mcp_reachable}" -eq 1 && -n "${MCP_API_KEY}" ]]; then
+  headers_file="$(mktemp)"
+  body_file="$(mktemp)"
+  trap 'rm -f "${headers_file:-}" "${body_file:-}" "${list_headers_file:-}" "${list_body_file:-}" "${tool_headers_file:-}" "${tool_body_file:-}"' EXIT
+
+  init_payload="{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"${MCP_PROTOCOL_VERSION}\",\"capabilities\":{\"roots\":{\"listChanged\":true},\"sampling\":{},\"elicitation\":{\"form\":{},\"url\":{}}},\"clientInfo\":{\"name\":\"self-serve-doctor\",\"version\":\"1.0.0\"}}}"
+  http_code="$(post_json "${SERVER_URL}" "${init_payload}" "${headers_file}" "${body_file}" "X-API-Key: ${MCP_API_KEY}")"
+
+  if [[ "${http_code}" == "200" ]]; then
+    session_id="$(awk -F': ' 'tolower($1)=="mcp-session-id" {gsub("\r", "", $2); print $2}' "${headers_file}")"
+    negotiated_protocol_version="$(grep -o '"protocolVersion"[[:space:]]*:[[:space:]]*"[^"]*"' "${body_file}" | head -n 1 | sed 's/.*"protocolVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+    if [[ -n "${session_id}" ]]; then
+      pass "MCP initialize succeeded and returned a session id"
+    else
+      fail "MCP initialize succeeded but did not return Mcp-Session-Id."
+    fi
+    if [[ "${negotiated_protocol_version}" == "${MCP_PROTOCOL_VERSION}" ]]; then
+      pass "MCP negotiated protocol ${negotiated_protocol_version}"
+    elif [[ -n "${negotiated_protocol_version}" ]]; then
+      fail "MCP negotiated protocol ${negotiated_protocol_version}, expected ${MCP_PROTOCOL_VERSION}. Upgrade the MCP/Spring AI transport before release."
+    else
+      fail "MCP initialize response did not include a protocolVersion."
+    fi
+  else
+    response_body="$(cat "${body_file}")"
+    fail "MCP initialize failed with HTTP ${http_code}. Response: ${response_body}"
+  fi
+
+  if [[ -n "${session_id}" ]]; then
+    follow_up_protocol_version="${negotiated_protocol_version:-${MCP_PROTOCOL_VERSION}}"
+    list_headers_file="$(mktemp)"
+    list_body_file="$(mktemp)"
+    list_payload='{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+    http_code="$(post_json "${SERVER_URL}" "${list_payload}" "${list_headers_file}" "${list_body_file}" "X-API-Key: ${MCP_API_KEY}" "Mcp-Session-Id: ${session_id}" "MCP-Protocol-Version: ${follow_up_protocol_version}")"
+
+    if [[ "${http_code}" == "200" ]] && grep -q '"result"' "${list_body_file}" && ! grep -q 'NullPointerException' "${list_body_file}"; then
+      pass "tools/list succeeded through the real MCP endpoint"
+      required_guided_tools=(
+        zap_crawl_start
+        zap_crawl_status
+        zap_passive_scan_wait
+        zap_passive_scan_status
+        zap_findings_summary
+        zap_report_generate
+        zap_report_read
+        zap_scan_history_release_evidence
+        zap_scan_history_customer_handoff
+      )
+      for tool in "${required_guided_tools[@]}"; do
+        require_tool_in_list "${tool}" "${list_body_file}"
+      done
+    else
+      response_body="$(cat "${list_body_file}")"
+      fail "tools/list failed with HTTP ${http_code}. Response: ${response_body}"
+    fi
+
+    if [[ "${SKIP_TOOL_CALL}" -eq 0 ]]; then
+      tool_headers_file="$(mktemp)"
+      tool_body_file="$(mktemp)"
+      tool_payload='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"zap_passive_scan_status","arguments":{}}}'
+      http_code="$(post_json "${SERVER_URL}" "${tool_payload}" "${tool_headers_file}" "${tool_body_file}" "X-API-Key: ${MCP_API_KEY}" "Mcp-Session-Id: ${session_id}" "MCP-Protocol-Version: ${follow_up_protocol_version}")"
+
+      if [[ "${http_code}" == "200" ]] && ! grep -q '"error"' "${tool_body_file}" && ! grep -q 'NullPointerException' "${tool_body_file}"; then
+        pass "zap_passive_scan_status succeeded as a harmless tool probe"
+      else
+        response_body="$(cat "${tool_body_file}")"
+        fail "zap_passive_scan_status failed with HTTP ${http_code}. Response: ${response_body}"
+      fi
+    fi
+  fi
+fi
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  printf '\nDoctor found %d blocking issue(s).\n' "${#FAILURES[@]}" >&2
+  exit 1
+fi
+
+cat <<'EOF'
+
+Self-serve API-key path looks healthy.
+
+Next steps:
+- Cursor: copy examples/cursor/mcp.json into your Cursor MCP config and keep MCP_API_KEY in your shell environment.
+- Open WebUI: open http://localhost:3000 when the default stack is running.
+- First-run guide: docs/getting-started/SELF_SERVE_FIRST_RUN.md
+- Published docs route: docs/src/content/docs/getting-started/self-serve-first-run.md
+EOF

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,10 +1,7 @@
-# Development override - Use fast JVM build (2-3 min vs 20+ min native)
+# Development override - keep the same runtime behavior as the base stack,
+# but use the faster JVM image build for local iteration.
 services:
   mcp-server:
     build:
       dockerfile: Dockerfile  # JVM image - fast builds
     image: mcp-zap-server:dev
-    environment:
-      # Development defaults
-      MCP_SECURITY_ENABLED: "false"
-      SPRING_PROFILES_ACTIVE: dev

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
 					label: 'Mission Control',
 					items: [
 						{ label: 'root@localhost:~', link: '/' },
+						{ slug: 'getting-started/self-serve-first-run' },
 						{ slug: 'getting-started/authentication-quick-start' },
 						{ slug: 'getting-started/tool-surfaces' },
 						{ slug: 'getting-started/mcp-client-authentication' },

--- a/docs/getting-started/SELF_SERVE_FIRST_RUN.md
+++ b/docs/getting-started/SELF_SERVE_FIRST_RUN.md
@@ -1,0 +1,100 @@
+# Self-Serve First Run
+
+Use this path when you want the fastest honest route from clone to a real
+findings summary with a supported API-key MCP client.
+
+The supported self-serve contract for this cycle is:
+
+- API-key auth
+- a client that can send custom headers to a remote MCP server
+- local Docker Compose for the default quick-start runtime
+
+## 1. Bootstrap Local Settings
+
+```bash
+git clone https://github.com/dtkmn/mcp-zap-server.git
+cd mcp-zap-server
+./bin/bootstrap-local.sh
+```
+
+This creates `.env`, generates `MCP_API_KEY`, prepares the ZAP workspace, and
+enables localhost/private-network scanning so the bundled demo targets work.
+
+## 2. Start The Stack
+
+```bash
+./dev.sh
+```
+
+Default local services:
+
+- MCP server: `http://localhost:7456/mcp`
+- Open WebUI: `http://localhost:3000`
+- host preview for Juice Shop: `http://localhost:3001`
+- host preview for Petstore: `http://localhost:3002`
+
+Important: when ZAP scans the bundled demo targets from inside Compose, use the
+container-reachable URLs:
+
+- `http://juice-shop:3000`
+- `http://petstore:8080`
+
+Do not tell the MCP tools to scan `http://localhost:3001` or
+`http://localhost:3002`. Those host mappings are for your browser, not for the
+scanner running inside Docker.
+
+## 3. Run The Doctor
+
+```bash
+./bin/self-serve-doctor.sh
+```
+
+This checks Docker, the local stack, API-key auth, MCP initialize,
+`tools/list`, the guided scan/report/evidence tool surface, and one harmless
+tool call.
+
+## 4. Connect A Client
+
+### Cursor
+
+- Start from [examples/cursor/mcp.json](../../examples/cursor/mcp.json).
+- Validated local user-wide config path: `~/.cursor/mcp.json`.
+- If Cursor inherits your shell environment, `${env:MCP_API_KEY}` is fine.
+- If GUI-launched Cursor does not inherit that environment, paste the actual
+  `MCP_API_KEY` value from `.env` into the `X-API-Key` header and restart
+  Cursor.
+- Point Cursor at `http://localhost:7456/mcp`.
+
+### Open WebUI
+
+- Start the stack with `./dev.sh`.
+- Open `http://localhost:3000`.
+- The default Compose stack wires Open WebUI to the local MCP server with the
+  generated API key.
+
+## 5. Use The Guided Happy Path
+
+For the full target-to-evidence workflow, use the
+[MCP Client Scan-To-Evidence Guide](https://danieltse.org/mcp-zap-server/scanning/mcp-client-scan-to-evidence/).
+
+Use prompts like these:
+
+1. `List the available ZAP tools and explain the safest first scan path.`
+2. `Start a spider scan on http://juice-shop:3000.`
+3. `Wait for passive analysis to finish and give me a findings summary for http://juice-shop:3000.`
+4. `Generate an HTML report for http://juice-shop:3000 and read it back through MCP.`
+5. `Create release evidence and a customer-safe handoff for http://juice-shop:3000.`
+
+That is enough to prove the end-to-end self-serve path without dragging a new
+user through every advanced feature in the repo.
+
+## 6. If It Breaks
+
+Use this order:
+
+1. `./bin/self-serve-doctor.sh`
+2. `docker compose logs -f mcp-server`
+3. `docker compose logs -f zap`
+
+If you are still stuck after that, the failure is probably real and worth
+fixing in the product surface, not just papering over in docs.

--- a/docs/src/content/docs/getting-started/mcp-client-authentication.md
+++ b/docs/src/content/docs/getting-started/mcp-client-authentication.md
@@ -17,6 +17,8 @@ The server supports:
 
 The practical truth: API-key mode is still the easiest self-serve client setup. Not every MCP desktop client handles remote HTTP transport, custom auth headers, or JWT refresh the same way.
 
+If you are starting from a fresh clone, use [Self-Serve First Run](./self-serve-first-run/) before tuning client-specific details here.
+
 ## Recommended Paths
 
 Use one of these paths:

--- a/docs/src/content/docs/getting-started/self-serve-first-run.md
+++ b/docs/src/content/docs/getting-started/self-serve-first-run.md
@@ -1,0 +1,105 @@
+---
+title: "Self-Serve First Run"
+editUrl: false
+description: "Clone, bootstrap, start the local stack, connect Cursor or Open WebUI, and run the guided scan-to-evidence path."
+---
+
+Use this path when you want the fastest honest route from clone to a real
+findings summary with a supported API-key MCP client.
+
+The supported self-serve contract for this cycle is:
+
+- API-key auth
+- a client that can send custom headers to a remote MCP server
+- local Docker Compose for the default quick-start runtime
+
+## 1. Bootstrap Local Settings
+
+```bash
+git clone https://github.com/dtkmn/mcp-zap-server.git
+cd mcp-zap-server
+./bin/bootstrap-local.sh
+```
+
+This creates `.env`, generates `MCP_API_KEY`, prepares the ZAP workspace, and
+enables localhost/private-network scanning so the bundled demo targets work.
+
+## 2. Start The Stack
+
+```bash
+./dev.sh
+```
+
+Default local services:
+
+- MCP server: `http://localhost:7456/mcp`
+- Open WebUI: `http://localhost:3000`
+- host preview for Juice Shop: `http://localhost:3001`
+- host preview for Petstore: `http://localhost:3002`
+
+Important: when ZAP scans the bundled demo targets from inside Compose, use the
+container-reachable URLs:
+
+- `http://juice-shop:3000`
+- `http://petstore:8080`
+
+Do not tell the MCP tools to scan `http://localhost:3001` or
+`http://localhost:3002`. Those host mappings are for your browser, not for the
+scanner running inside Docker.
+
+## 3. Run The Doctor
+
+```bash
+./bin/self-serve-doctor.sh
+```
+
+This checks Docker, the local stack, API-key auth, MCP initialize,
+`tools/list`, the guided scan/report/evidence tool surface, and one harmless
+tool call.
+
+## 4. Connect A Client
+
+### Cursor
+
+- Start from the repo's
+  [Cursor example](https://github.com/dtkmn/mcp-zap-server/blob/main/examples/cursor/mcp.json).
+- Validated local user-wide config path: `~/.cursor/mcp.json`.
+- If Cursor inherits your shell environment, `${env:MCP_API_KEY}` is fine.
+- If GUI-launched Cursor does not inherit that environment, paste the actual
+  `MCP_API_KEY` value from `.env` into the `X-API-Key` header and restart
+  Cursor.
+- Point Cursor at `http://localhost:7456/mcp`.
+
+### Open WebUI
+
+- Start the stack with `./dev.sh`.
+- Open `http://localhost:3000`.
+- The default Compose stack wires Open WebUI to the local MCP server with the
+  generated API key.
+
+## 5. Use The Guided Happy Path
+
+For the full target-to-evidence workflow, use the
+[MCP Client Scan-To-Evidence Guide](../scanning/mcp-client-scan-to-evidence/).
+
+Use prompts like these:
+
+1. `List the available ZAP tools and explain the safest first scan path.`
+2. `Start a spider scan on http://juice-shop:3000.`
+3. `Wait for passive analysis to finish and give me a findings summary for http://juice-shop:3000.`
+4. `Generate an HTML report for http://juice-shop:3000 and read it back through MCP.`
+5. `Create release evidence and a customer-safe handoff for http://juice-shop:3000.`
+
+That is enough to prove the end-to-end self-serve path without dragging a new
+user through every advanced feature in the repo.
+
+## 6. If It Breaks
+
+Use this order:
+
+1. `./bin/self-serve-doctor.sh`
+2. `docker compose logs -f mcp-server`
+3. `docker compose logs -f zap`
+
+If you are still stuck after that, the failure is probably real and worth
+fixing in the product surface, not just papering over in docs.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -66,6 +66,10 @@ editUrl: false
       <h3>&gt; [06] SEEDED_API_GATE</h3>
       <p>Adopt seeded API traffic, reviewed baselines, and enforcement without turning CI into noise.</p>
     </a>
+    <a class="mission-card" href="./extensions/extension-api-release-policy/">
+      <h3>&gt; [07] EXTENSION_POLICY</h3>
+      <p>See what must be true before the extension API becomes a public compatibility promise.</p>
+    </a>
   </div>
 
   <span class="section-label">tail -f /var/log/capabilities.txt</span>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -42,25 +42,25 @@ editUrl: false
   <span class="section-label">./execute_mission.sh</span>
 
   <div class="mission-grid">
+    <a class="mission-card" href="./getting-started/self-serve-first-run/">
+      <h3>&gt; [01] SELF_SERVE_FIRST_RUN</h3>
+      <p>Clone, bootstrap, start the local stack, connect Cursor or Open WebUI, and run the guided path.</p>
+    </a>
     <a class="mission-card" href="./getting-started/tool-surfaces/">
-      <h3>&gt; [01] TOOL_SURFACES</h3>
+      <h3>&gt; [02] TOOL_SURFACES</h3>
       <p>Choose the default guided surface or unlock the expert workflow controls.</p>
     </a>
     <a class="mission-card" href="./scanning/scan-execution-modes/">
-      <h3>&gt; [02] EXECUTION_MODES</h3>
+      <h3>&gt; [03] EXECUTION_MODES</h3>
       <p>Understand guided, direct, queue-managed, and automation execution paths.</p>
     </a>
     <a class="mission-card" href="./getting-started/tool-scope-authorization/">
-      <h3>&gt; [03] TOOL_SCOPE_AUTHZ</h3>
+      <h3>&gt; [04] TOOL_SCOPE_AUTHZ</h3>
       <p>Control who can discover and invoke each MCP action.</p>
     </a>
     <a class="mission-card" href="./operations/observability/">
-      <h3>&gt; [04] OBSERVABILITY</h3>
+      <h3>&gt; [05] OBSERVABILITY</h3>
       <p>Trace requests with correlation IDs, audit events, and bounded metrics.</p>
-    </a>
-    <a class="mission-card" href="./extensions/extension-api-release-policy/">
-      <h3>&gt; [05] EXTENSION_POLICY</h3>
-      <p>See what must be true before the extension API becomes a public compatibility promise.</p>
     </a>
     <a class="mission-card" href="./scanning/seeded-api-gate-playbook/">
       <h3>&gt; [06] SEEDED_API_GATE</h3>

--- a/docs/src/content/docs/operations/local-ha-compose.md
+++ b/docs/src/content/docs/operations/local-ha-compose.md
@@ -88,4 +88,4 @@ docker compose -f docker-compose.yml -f docker-compose.ha.yml down -v
 - The gateway is session-aware: streamable MCP over HTTP needs sticky ingress when session state lives in-memory on each replica.
 - In local Compose, `ha.sh` owns the generated gateway config because explicit per-replica upstream entries are required for nginx hashing to behave correctly with scaled Docker services.
 - MCP replicas assume the shared Postgres schema has already been migrated; they no longer create queue/JWT tables on startup.
-- The default dev override still disables MCP auth (`MCP_SECURITY_MODE=none`). If you want auth in the HA simulation, add another override or export the relevant environment variables.
+- The dev override preserves the base API-key/security behavior. Only add an override when you intentionally want to test `none`, JWT, or another auth mode.

--- a/examples/cursor/mcp.json
+++ b/examples/cursor/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "mcp-zap-server": {
+      "url": "http://localhost:7456/mcp",
+      "headers": {
+        "X-API-Key": "${env:MCP_API_KEY}"
+      }
+    }
+  }
+}

--- a/llms-install.md
+++ b/llms-install.md
@@ -145,7 +145,7 @@ X-API-Key: $MCP_API_KEY
 
 The `mcp-zap-wrk:/zap/wrk` volume must be mounted into both containers. ZAP writes report artifacts there, and the MCP server reads those same paths back for report and evidence-handoff tools. The MCP container is run as UID/GID `1000:1000` to match the standard `zaproxy/zap-stable` container user, so report directories remain writable by both containers.
 
-This default guided standalone path has been smoke-tested with MCP `initialize`, `tools/list`, `zap_passive_scan_status`, and `zap_report_generate` against a separate ZAP container. If you need expert tools such as `zap_report_read`, add `-e MCP_SERVER_TOOLS_SURFACE=expert` to the MCP container run command.
+This default guided standalone path has been smoke-tested with MCP `initialize`, `tools/list`, `zap_passive_scan_status`, `zap_report_generate`, and `zap_report_read` against a separate ZAP container. Keep `MCP_SERVER_TOOLS_SURFACE=guided` for normal report readback. Use `-e MCP_SERVER_TOOLS_SURFACE=expert` only when you need lower-level ZAP tools outside the guided surface.
 
 ## Safe First Test
 

--- a/src/test/java/mcp/server/zap/architecture/SelfServeFirstRunDocsTest.java
+++ b/src/test/java/mcp/server/zap/architecture/SelfServeFirstRunDocsTest.java
@@ -1,0 +1,101 @@
+package mcp.server.zap.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class SelfServeFirstRunDocsTest {
+
+    private static final Path README = Path.of("README.md");
+    private static final Path RAW_GUIDE = Path.of("docs/getting-started/SELF_SERVE_FIRST_RUN.md");
+    private static final Path STARLIGHT_GUIDE =
+            Path.of("docs/src/content/docs/getting-started/self-serve-first-run.md");
+    private static final Path STARLIGHT_CONFIG = Path.of("docs/astro.config.mjs");
+    private static final Path STARLIGHT_INDEX = Path.of("docs/src/content/docs/index.mdx");
+    private static final Path CLIENT_AUTH_DOC =
+            Path.of("docs/src/content/docs/getting-started/mcp-client-authentication.md");
+    private static final Path CURSOR_EXAMPLE = Path.of("examples/cursor/mcp.json");
+    private static final Path DOCTOR = Path.of("bin/self-serve-doctor.sh");
+    private static final Path BOOTSTRAP = Path.of("bin/bootstrap-local.sh");
+    private static final Path DEV_COMPOSE = Path.of("docker-compose.dev.yml");
+
+    @Test
+    void readmeStartsNewUsersOnTheSupportedSelfServePath() throws IOException {
+        String readme = Files.readString(README);
+
+        assertThat(readme)
+                .contains("./bin/bootstrap-local.sh")
+                .contains("./dev.sh")
+                .contains("./bin/self-serve-doctor.sh")
+                .contains("examples/cursor/mcp.json")
+                .contains("getting-started/self-serve-first-run")
+                .contains("http://juice-shop:3000")
+                .contains("http://petstore:8080")
+                .doesNotContain("Generate values for ZAP_API_KEY and MCP_API_KEY");
+    }
+
+    @Test
+    void docsSiteSurfacesTheFirstRunGuide() throws IOException {
+        assertThat(Files.readString(STARLIGHT_CONFIG))
+                .contains("slug: 'getting-started/self-serve-first-run'");
+        assertThat(Files.readString(STARLIGHT_INDEX))
+                .contains("./getting-started/self-serve-first-run/")
+                .contains("SELF_SERVE_FIRST_RUN");
+        assertThat(Files.readString(CLIENT_AUTH_DOC))
+                .contains("[Self-Serve First Run](./self-serve-first-run/)");
+
+        assertThat(Files.readString(RAW_GUIDE))
+                .contains("git clone https://github.com/dtkmn/mcp-zap-server.git")
+                .contains("./bin/self-serve-doctor.sh")
+                .contains("http://juice-shop:3000")
+                .contains("Create release evidence and a customer-safe handoff");
+
+        assertThat(Files.readString(STARLIGHT_GUIDE))
+                .contains("title: \"Self-Serve First Run\"")
+                .contains("git clone https://github.com/dtkmn/mcp-zap-server.git")
+                .contains("./bin/self-serve-doctor.sh")
+                .contains("http://juice-shop:3000")
+                .contains("Create release evidence and a customer-safe handoff");
+    }
+
+    @Test
+    void cursorExampleUsesTheGeneratedApiKeyHeader() throws IOException {
+        assertThat(Files.readString(CURSOR_EXAMPLE))
+                .contains("\"url\": \"http://localhost:7456/mcp\"")
+                .contains("\"X-API-Key\": \"${env:MCP_API_KEY}\"")
+                .doesNotContain("Authorization")
+                .doesNotContain("Bearer");
+    }
+
+    @Test
+    void doctorVerifiesTheGuidedScanReportAndEvidenceSurface() throws IOException {
+        String doctor = Files.readString(DOCTOR);
+
+        assertThat(doctor)
+                .contains("guided scan, report, and evidence tool visibility")
+                .contains("required_guided_tools=(")
+                .contains("zap_crawl_start")
+                .contains("zap_passive_scan_wait")
+                .contains("zap_findings_summary")
+                .contains("zap_report_generate")
+                .contains("zap_report_read")
+                .contains("zap_scan_history_release_evidence")
+                .contains("zap_scan_history_customer_handoff")
+                .contains("docs/getting-started/SELF_SERVE_FIRST_RUN.md")
+                .contains("docs/src/content/docs/getting-started/self-serve-first-run.md")
+                .doesNotContain("--with-open-webui");
+
+        assertThat(Files.readString(BOOTSTRAP)).doesNotContain("--with-open-webui");
+    }
+
+    @Test
+    void devComposeDoesNotDisableTheApiKeyFirstRunPath() throws IOException {
+        assertThat(Files.readString(DEV_COMPOSE))
+                .contains("keep the same runtime behavior as the base stack")
+                .doesNotContain("MCP_SECURITY_ENABLED: \"false\"")
+                .doesNotContain("MCP_SECURITY_MODE=none");
+    }
+}

--- a/src/test/java/mcp/server/zap/architecture/SelfServeFirstRunDocsTest.java
+++ b/src/test/java/mcp/server/zap/architecture/SelfServeFirstRunDocsTest.java
@@ -18,6 +18,8 @@ class SelfServeFirstRunDocsTest {
     private static final Path CLIENT_AUTH_DOC =
             Path.of("docs/src/content/docs/getting-started/mcp-client-authentication.md");
     private static final Path CURSOR_EXAMPLE = Path.of("examples/cursor/mcp.json");
+    private static final Path MARKETPLACE_METADATA = Path.of(".mcp/server.json");
+    private static final Path LLMS_INSTALL = Path.of("llms-install.md");
     private static final Path DOCTOR = Path.of("bin/self-serve-doctor.sh");
     private static final Path BOOTSTRAP = Path.of("bin/bootstrap-local.sh");
     private static final Path DEV_COMPOSE = Path.of("docker-compose.dev.yml");
@@ -89,6 +91,19 @@ class SelfServeFirstRunDocsTest {
                 .doesNotContain("--with-open-webui");
 
         assertThat(Files.readString(BOOTSTRAP)).doesNotContain("--with-open-webui");
+    }
+
+    @Test
+    void marketplaceGuidanceKeepsReportReadbackOnTheGuidedSurface() throws IOException {
+        assertThat(Files.readString(MARKETPLACE_METADATA))
+                .contains("including report readback")
+                .contains("Use expert only when clients need raw ZAP tools outside the guided surface")
+                .doesNotContain("expert when clients need raw ZAP tools such as zap_report_read");
+
+        assertThat(Files.readString(LLMS_INSTALL))
+                .contains("Keep `MCP_SERVER_TOOLS_SURFACE=guided` for normal report readback")
+                .contains("Use `-e MCP_SERVER_TOOLS_SURFACE=expert` only when you need lower-level ZAP tools outside the guided surface")
+                .doesNotContain("If you need expert tools such as `zap_report_read`");
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces a comprehensive and tested "Self-Serve First Run" path for new users, making it much easier to get started with the MCP ZAP Server. The changes ensure that the documentation, configuration, and example files all guide users through a reliable, API-key-based local workflow, and that this path is validated by automated tests. The guided tool surface is clarified to include report readback by default, and the documentation site and examples are updated to reinforce this recommended flow.

**Self-Serve First Run Path and Documentation:**

* Added a new "Self-Serve First Run" guide in both Markdown and Starlight docs, detailing a step-by-step, API-key-based local setup and workflow for new users (`docs/getting-started/SELF_SERVE_FIRST_RUN.md`, `docs/src/content/docs/getting-started/self-serve-first-run.md`). [[1]](diffhunk://#diff-ddd6a5a9305e8ba4e304057efacb647cc508d43186f9a3ee96f309de933d4956R1-R100) [[2]](diffhunk://#diff-cb9195a5772b2cef2790130a0970d12e36e9d3760071da0067e3fd6a11c51ed5R1-R105)
* Updated `README.md` and documentation site navigation to highlight and link to the self-serve guide, and revised setup instructions to use supported scripts instead of manual `.env` editing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R76) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R178) [[3]](diffhunk://#diff-ae669176eb85e8e00b8a6b2541c7d55deba8790db6fba3384459244bc8c8e4f7R45-R72) [[4]](diffhunk://#diff-8093fd52e3174c122757b47959fa9539848a76a450f2366300bf421f31c7a09fR37) [[5]](diffhunk://#diff-63b9b28cdff3c9c8d0f7c59495957e0ff2291f808f09f48472246ce181ea7d5bR20-R21)

**Configuration and Example Updates:**

* Added a new `examples/cursor/mcp.json` showing the correct API-key header usage for Cursor clients, and referenced it throughout the docs.
* Updated `.mcp/server.json` and `llms-install.md` to clarify that report readback is included in the guided tool surface, and that "expert" mode is only for advanced, lower-level ZAP tools. [[1]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL78-R78) [[2]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL162-R162) [[3]](diffhunk://#diff-b9b42aca071016de2981c979708715cc6cd215563cb709f59abd0f66e11943efL148-R148)
* Cleaned up `docker-compose.dev.yml` to avoid disabling API-key auth in development, ensuring the first-run path works out of the box.
* Updated HA documentation to clarify that the dev override preserves the base API-key/security behavior.

**Automated Testing:**

* Added `SelfServeFirstRunDocsTest.java` to verify that all documentation, scripts, and example files consistently guide users through the supported self-serve path, and that advanced/expert features are not required for the default workflow.

These changes collectively ensure that new users have a smooth, reliable, and well-documented path to get started, and that this path is maintained and tested as the project evolves.