### PR TITLE
Enhance authentication with profile support and improve security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Changed `zap_auth_session_prepare` to accept only `profileId` and `targetUrl`. Deployments must replace `MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES` and `MCP_AUTH_BOOTSTRAP_ALLOW_INLINE_SECRETS` with operator-managed `mcp.server.auth.bootstrap.profiles` configuration.
+- Added executable-JAR, Compose, and Helm migration recipes with secret injection, required restart behavior, and live prepare/validate verification.
 - Updated to Boot-managed Testcontainers `2.0.5` modules and run tagged Docker integration tests before main and release image publication.
 - Updated Spring Boot to `4.1.0` and aligned the standalone extension and CI dependency-resolution proofs with the managed runtime.
 - Updated the runtime to consume `io.github.dtkmn:mcp-gateway-core` and `io.github.dtkmn:mcp-gateway-spring-webflux` `0.7.1`.
 - Limited continuous container publication to successful `main` pushes while keeping CI builds on development and feature branches.
+
+### Security
+- Bound each guided-auth credential and login configuration to one operator-approved canonical origin, removed caller-selected credentials and login settings, and recheck that origin before validation and authenticated crawl or attack dispatch.
+- Made each guided profile's ZAP context scope immutable and origin-wide, validate login indicators before secret resolution or engine mutation, and keep credential-source metadata out of MCP caller errors.
+- Made form-login validation fail closed unless ZAP reports `likelyAuthenticated=true`, and reject terminal-dot target hosts before URL policy checks or engine dispatch.
+- Made the JVM container run as UID/GID 1000 and made the authenticated-profile Helm migration verify and deploy the exact main-commit image tag.
 
 ## [0.9.1] - 2026-06-26
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,14 @@ RUN gradle bootJar -x test && \
 # Runtime stage
 FROM eclipse-temurin:25-jre-alpine
 LABEL io.modelcontextprotocol.server.name="io.github.dtkmn/mcp-zap-server"
-RUN apk add --no-cache --upgrade curl p11-kit p11-kit-trust
+RUN apk add --no-cache --upgrade curl p11-kit p11-kit-trust && \
+    addgroup -S -g 1000 app && \
+    adduser -S -D -H -u 1000 -G app app && \
+    mkdir -p /app /zap/wrk && \
+    chown -R 1000:1000 /app /zap/wrk
 WORKDIR /app
-COPY --from=builder /tmp/app.jar ./app.jar
+COPY --chown=1000:1000 --from=builder /tmp/app.jar ./app.jar
+USER 1000:1000
 EXPOSE 7456
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:7456/actuator/health || exit 1

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The default posture is intentionally conservative:
 - `none` mode is for explicit local dev/test only.
 - Docker Compose binds published ports to loopback by default.
 - URL validation blocks localhost, private networks, and link-local targets by default.
-- Guided auth uses credential reference allowlisting for server-side secrets.
+- Guided auth uses operator-managed profiles that bind exact server-side credential references and login settings to one approved origin; callers provide only `profileId` and `targetUrl`.
 - Public auth exchange endpoints are rate-limited.
 - MCP request bodies have a hard early size cap.
 

--- a/docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md
+++ b/docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md
@@ -12,13 +12,13 @@ capability gap.
 Supported in the current gateway window:
 
 - form-login bootstrap backed by ZAP context and user configuration
-- bearer/API-key credential-reference preparation at the gateway layer
+- bearer/API-key profile preparation at the gateway layer
 - guided `zap_auth_session_prepare` and `zap_auth_session_validate`
 - authenticated guided crawl/attack with prepared form-login sessions
 
 Important caveat:
 
-- bearer/API-key sessions validate credential references, but current guided ZAP
+- bearer/API-key sessions validate their configured credential references, but current guided ZAP
   flows do not automatically inject those headers into engine execution yet
 
 Unsupported today:
@@ -34,8 +34,8 @@ Capture these before changing anything:
 
 - `correlationId` from the client response or request headers
 - tool name: `zap_auth_session_prepare`, `zap_auth_session_validate`,
-  `zap_crawl`, or `zap_attack`
-- `authKind`
+  `zap_crawl_start`, or `zap_attack_start`
+- `profileId` and the profile's configured auth kind
 - `targetUrl`
 - whether the session reports `Engine Binding: ZAP context/user ready` or
   `Engine Binding: gateway contract only`
@@ -45,20 +45,17 @@ Then classify the failure:
 
 | Symptom | Likely Cause | First Action |
 | --- | --- | --- |
-| `authKind must be one of: form, bearer, api-key` | Unsupported or misspelled auth kind | Use `form`, `bearer`, or `api-key` only. |
+| `Unknown auth profile ID` | Caller selected a profile that is not configured | Use an operator-configured profile ID or add the profile before retrying. |
+| `Auth profile ... is invalid` | Operator profile is incomplete or internally inconsistent | Fix the profile configuration and restart before exposing the service. |
 | `targetUrl cannot be null or blank` | Missing target URL | Supply the target host or base URL. |
-| `loginUrl cannot be null or blank` | Form login request is incomplete | Supply the actual login form URL. |
-| `username cannot be null or blank` | Form login username missing | Supply the login username. |
-| `loggedInIndicatorRegex cannot be null or blank` | No success indicator for validation | Provide a regex that appears only after login. |
-| `Provide credentialReference or inlineSecret` | No secret source | Prefer `credentialReference`. |
-| `inlineSecret is disabled by default` | Inline secret used outside local mode | Use `env:NAME` or `file:/absolute/path`, or explicitly enable inline secrets only for local workflows. |
-| `credentialReference is not in the operator allowlist` | Caller selected an env var or file path that operators did not pre-approve | Add the exact `env:NAME` or `file:/absolute/path` to `MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES`, or reject the workflow. |
-| `Environment variable ... is missing or blank` | Secret env var unavailable to the MCP process | Fix the deployment secret/env injection. |
+| `targetUrl origin is not authorized for auth profile` | Caller selected a target outside the profile's exact scheme, host, and port | Use a target path on the configured origin or select the correct profile. |
+| `loginUrl origin is not authorized for auth profile` | Operator configured a form login URL outside the credential's allowed origin | Correct the profile; never widen the origin merely to make the request pass. |
+| `loginUrl cannot be null or blank` | Form profile is incomplete | Configure the actual login form URL in the profile. |
+| `username cannot be null or blank` | Form profile username missing | Configure the login username in the profile. |
+| `loggedInIndicatorRegex cannot be null or blank` | Form profile has no success indicator | Configure a regex that appears only after login. |
 | `credentialReference file path must be absolute` | Relative secret path | Use `file:/absolute/path`. |
-| `Unable to read credentialReference file` | File missing or unreadable | Fix mount path and file permissions for the MCP runtime. |
-| `reference_missing` | Header session was prepared from inline secret | Re-prepare with `credentialReference`. |
+| `Auth profile credential could not be resolved` | Configured environment variable or secret file is missing, blank, or unreadable | Inspect the correlated operator log for the exact environment name or file path, then fix deployment injection or mount permissions. Do not return that metadata to MCP callers. |
 | `authentication_failed` | ZAP could not authenticate the configured user | Check credentials, login URL, field names, and login indicators. |
-| `loginUrl must share the same origin as targetUrl` | Form login points to a different scheme, host, or port than the scan target | Keep login and target on the same origin; do not use auth bootstrap for cross-origin credential forwarding. |
 | `usernameField contains unsupported characters` or `passwordField contains unsupported characters` | Form field name could inject extra ZAP auth config parameters | Use simple field names containing letters, numbers, dot, underscore, dash, colon, or brackets. |
 | `Unknown auth session ID` | Session ID lost or wrong | Re-run `zap_auth_session_prepare`. |
 | `form-login sessions only` | Header session passed to guided scan | Use a form-login session or omit `authSessionId`. |
@@ -68,19 +65,20 @@ Then classify the failure:
 
 Form-login preparation needs all of this:
 
+- operator-configured `profileId`
 - `targetUrl`
-- `loginUrl`
-- `username`
-- operator-allowlisted `credentialReference` or allowed local `inlineSecret`
-- `loggedInIndicatorRegex`
+- profile `allowed-origin`
+- profile `login-url`
+- profile `username`
+- exact profile `credential-reference`
+- profile `logged-in-indicator-regex`
 
-Optional but often necessary:
+Optional profile settings:
 
-- `contextName`
-- `userName`
-- `usernameField`
-- `passwordField`
-- `loggedOutIndicatorRegex`
+- profile `zap-user-name`
+- profile `username-field`
+- profile `password-field`
+- profile `logged-out-indicator-regex`
 
 If preparation fails before a session ID is returned, fix input or secret
 resolution first. There is no session to validate yet.
@@ -89,13 +87,13 @@ If preparation returns a session but validation fails:
 
 1. Confirm the credential source resolves inside the MCP runtime, not only on
    the operator laptop.
-2. Confirm `loginUrl` is the form POST entrypoint ZAP can use.
-3. Confirm `usernameField` and `passwordField` match the form field names.
-4. Confirm `loggedInIndicatorRegex` appears only after successful login.
-5. Confirm `loggedOutIndicatorRegex`, if supplied, does not also match
+2. Confirm `login-url` is the form POST entrypoint ZAP can use.
+3. Confirm `username-field` and `password-field` match the form field names.
+4. Confirm `logged-in-indicator-regex` appears only after successful login.
+5. Confirm `logged-out-indicator-regex`, if supplied, does not also match
    authenticated pages.
-6. Use lower-level context/user tools only after the guided request is known to
-   be structurally correct.
+6. Do not mutate a guided profile's managed context with lower-level tools.
+   Fix the profile and prepare a new session; use separate contexts for expert flows.
 
 Validation output should include:
 
@@ -103,8 +101,8 @@ Validation output should include:
 - `contextId=...`
 - `userId=...`
 
-If `likelyAuthenticated=false`, do not continue to an authenticated scan and
-pretend the result is meaningful.
+If `likelyAuthenticated` is anything other than `true`, do not continue to an
+authenticated scan and pretend the result is meaningful.
 
 ## Staging Checklist: Form-Login Prepare And Validate
 
@@ -112,32 +110,35 @@ Use this checklist before calling an authenticated pilot ready. It is for
 staging/manual validation of form-login prepare and validate behavior, not for
 capturing real credentials in docs or tickets.
 
-Inputs to prepare:
+Operator profile:
 
-- `targetUrl=https://staging.example.test`
-- `authKind=form`
-- `credentialReference=env:STAGING_SCAN_PASSWORD` or
-  `credentialReference=file:/absolute/path/to/mounted/secret`
-- `MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES` includes the exact
-  reference, or an operator-approved prefix such as `env:STAGING_SCAN_*` or
-  `file:/var/run/secrets/mcp-zap/*`
-- file wildcards are directory containment rules; sibling-prefix paths and
-  symlink escapes are intentionally rejected
-- `sessionLabel=staging-form-auth`
-- `contextName=staging-form-auth`
-- `loginUrl=https://staging.example.test/login`
+- `id=staging-form`
+- `kind=form`
+- `allowed-origin=https://staging.example.test`
+- `credential-reference=env:STAGING_SCAN_PASSWORD` or
+  `credential-reference=file:/absolute/path/to/mounted/secret`
+- credential references are exact; wildcards and inline secrets are not supported
+- derived ZAP context `staging-form-auth` (profile ID plus `-auth`)
+- `login-url=https://staging.example.test/login`
 - `username=<scan-user-name>`
-- `usernameField=<login-form-username-field>`
-- `passwordField=<login-form-password-field>`
+- `username-field=<login-form-username-field>`
+- `password-field=<login-form-password-field>`
 - field names may contain letters, numbers, dot, underscore, dash, colon, or
   brackets only; ZAP auth config values are URL-encoded by the server
-- `loggedInIndicatorRegex=<text-only-visible-after-login>`
-- optional `loggedOutIndicatorRegex=<text-only-visible-before-login>`
+- `logged-in-indicator-regex=<text-only-visible-after-login>`
+- optional `logged-out-indicator-regex=<text-only-visible-before-login>`
+
+Inputs to prepare:
+
+- `profileId=staging-form`
+- `targetUrl=https://staging.example.test`
 
 Expected prepare evidence:
 
 - response starts with `Guided auth session prepared.`
+- response includes `Auth Profile: staging-form`
 - response includes `Auth Kind: form`
+- response includes `Authorized Origin: https://staging.example.test`
 - response includes `Provider: zap-form-login`
 - response includes `Engine Binding: ZAP context/user ready`
 - response includes `Context ID:` and `User ID:`
@@ -160,22 +161,20 @@ actually authenticated.
 
 ## Bearer And API-Key Prepare Failures
 
-Bearer and API-key bootstrap currently prepares a gateway credential-reference
+Bearer and API-key profiles currently prepare a gateway credential-reference
 session. It does not prove the target accepts that credential, and it does not
 automatically inject the header into current guided ZAP execution.
 
 Expected validation behavior:
 
-- `reference_valid` means the credential reference resolves
-- `reference_missing` means the session was prepared from inline secret and
-  cannot be revalidated later
+- `reference_valid` means the profile's credential reference resolves
 
 For production-like use:
 
-- use `credentialReference=env:NAME` or `credentialReference=file:/absolute/path`
+- configure an exact `credential-reference=env:NAME` or
+  `credential-reference=file:/absolute/path` in the profile
 - verify the secret is present in the MCP container or pod
-- verify the reference is allowlisted by operators
-- do not rely on inline secrets for repeatable operator workflows
+- verify `allowed-origin` is the exact relying origin
 - do not present header-based bootstrap as authenticated scan execution until
   header injection is implemented in the engine path
 
@@ -184,7 +183,7 @@ For production-like use:
 Authenticated guided crawl/attack currently accepts prepared form-login
 sessions only.
 
-If `zap_crawl` or `zap_attack` fails after adding `authSessionId`:
+If `zap_crawl_start` or `zap_attack_start` fails after adding `authSessionId`:
 
 1. Validate the session first with `zap_auth_session_validate`.
 2. Confirm the session reports `Auth Kind: form`.
@@ -202,13 +201,14 @@ For every auth bootstrap incident, capture:
 - request `correlationId`
 - MCP client ID and workspace ID
 - tool name and request ID
-- session ID, if one was created
+- SHA-256 fingerprint of the session ID, if one was created; never capture the raw session ID
 - validation outcome and diagnostics
 - relevant MCP service logs around the same `correlationId`
 - relevant ZAP logs for context/user authentication attempts
 
-Do not capture raw secrets in tickets, logs, screenshots, or support notes.
-Credential references are acceptable; secret values are not.
+Do not capture raw secrets or exact credential references in caller-visible errors,
+tickets, screenshots, or support notes. Exact environment names and mounted paths
+belong only in restricted operator logs. Secret values must never be logged.
 
 ## Escalation Rules
 
@@ -221,7 +221,7 @@ Escalate as product work, not operator configuration, when:
 
 Escalate as deployment work when:
 
-- env/file credential references do not resolve in the runtime
+- profile env/file credential references do not resolve in the runtime
 - secret mounts differ between MCP and ZAP containers
 - ingress, proxy, or target allowlist rules block the login flow
 

--- a/docs/operator/runbooks/PRODUCTION_SIMULATION_RUNBOOK.md
+++ b/docs/operator/runbooks/PRODUCTION_SIMULATION_RUNBOOK.md
@@ -80,16 +80,17 @@ Pre-flight configuration:
   bundle
 - the pilot policy bundle allows the staging host and the exact tools used in
   this scenario
-- the credential is supplied by `credentialReference`, not an inline secret
+- an operator-managed auth profile binds the staging origin, login settings,
+  and exact credential reference
 
 Run sequence:
 
-1. Call `zap_auth_session_prepare` with `authKind=form`, the staging
-   `targetUrl`, `loginUrl`, `username`, field names, login indicators, and a
-   credential reference.
-2. Record the response `correlationId`, `Session ID`, `Context ID`, `User ID`,
-   provider, and `Engine Binding`.
-3. Call `zap_auth_session_validate` with that session ID.
+1. Call `zap_auth_session_prepare` with the staging `profileId` and a
+   `targetUrl` on that profile's authorized origin.
+2. Record the response `correlationId`, `Auth Profile`, `Authorized Origin`,
+   `Context ID`, `User ID`, provider, and `Engine Binding`. Keep the raw session
+   ID only for this live workflow; retain only its SHA-256 fingerprint.
+3. Call `zap_auth_session_validate` with the raw session ID.
 4. Confirm `Valid: true`, `Outcome: authenticated`, and
    `likelyAuthenticated=true`.
 5. Call `zap_crawl_start` with the same target, `strategy=http`, and the
@@ -118,7 +119,7 @@ Expected operator evidence:
 | Evidence | Required proof |
 | --- | --- |
 | Correlation IDs | One for auth prepare, auth validate, crawl, attack, passive wait, findings, and report generation. |
-| Auth evidence | Session ID, context ID, user ID, provider, engine binding, validation outcome, and diagnostics. |
+| Auth evidence | Session ID SHA-256 fingerprint (never raw), context ID, user ID, provider, engine binding, validation outcome, and diagnostics. |
 | Policy evidence | `policy_decision` audit event with bounded tags and the same correlation ID as the tool call. |
 | Scan evidence | Guided operation ID plus backend scan ID or queued job ID where available. |
 | Passive evidence | Passive scan wait result after crawl and after attack. |

--- a/docs/src/content/docs/operations/production-simulation-runbook.md
+++ b/docs/src/content/docs/operations/production-simulation-runbook.md
@@ -53,12 +53,12 @@ one chain.
 
 Run sequence:
 
-1. Call `zap_auth_session_prepare` with `authKind=form`, the staging
-   `targetUrl`, `loginUrl`, `username`, field names, login indicators, and a
-   credential reference.
-2. Record the response `correlationId`, `Session ID`, `Context ID`, `User ID`,
-   provider, and `Engine Binding`.
-3. Call `zap_auth_session_validate` with that session ID.
+1. Call `zap_auth_session_prepare` with the staging `profileId` and a
+   `targetUrl` on that profile's authorized origin.
+2. Record the response `correlationId`, `Auth Profile`, `Authorized Origin`,
+   `Context ID`, `User ID`, provider, and `Engine Binding`. Keep the raw session
+   ID only for this live workflow; retain only its SHA-256 fingerprint.
+3. Call `zap_auth_session_validate` with the raw session ID.
 4. Confirm `Valid: true`, `Outcome: authenticated`, and
    `likelyAuthenticated=true`.
 5. Call `zap_crawl_start` with the same target, `strategy=http`, and the
@@ -87,7 +87,7 @@ Expected operator evidence:
 | Evidence | Required proof |
 | --- | --- |
 | Correlation IDs | One for auth prepare, auth validate, crawl, attack, passive wait, findings, and report generation. |
-| Auth evidence | Session ID, context ID, user ID, provider, engine binding, validation outcome, and diagnostics. |
+| Auth evidence | Session ID SHA-256 fingerprint (never raw), context ID, user ID, provider, engine binding, validation outcome, and diagnostics. |
 | Policy evidence | `policy_decision` audit event with bounded tags and the same correlation ID as the tool call. |
 | Scan evidence | Guided operation ID plus backend scan ID or queued job ID where available. |
 | Passive evidence | Passive scan wait result after crawl and after attack. |

--- a/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
+++ b/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
@@ -18,25 +18,356 @@ For 0.7.0 and later, start with guided auth bootstrap:
 
 These tools are available on the default `guided` surface. The lower-level ZAP context and user tools still exist on the `expert` surface, but they are the advanced path now.
 
+Treat guided profile contexts as managed state. Do not alter a returned context with expert auth tools; fix the profile and prepare a new session instead.
+
 ## Operator Secret Setup
 
-Guided auth expects credential references, not raw passwords in prompts.
+Guided auth uses operator-managed profiles. MCP callers select a profile and a target URL; they cannot choose or recombine its credential, login URL, or allowed origin.
 
-Recommended baseline:
+This is a deployment-level trust boundary, not tenant isolation:
 
-```bash
-MCP_AUTH_BOOTSTRAP_ALLOW_INLINE_SECRETS=false
-MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES=env:STAGING_SCAN_PASSWORD,file:/var/run/secrets/mcp-zap/*
+- every principal with `zap:auth:session:write` can select every auth profile configured in that deployment
+- profile IDs are selectors, not per-caller or per-workspace access controls
+- prepared session IDs are sensitive capabilities; do not log, share, or expose them beyond the scan workflow that created them
+- run separate MCP ZAP deployments for tenants or teams that must not share credential authority
+
+Keep the profile in external Spring configuration and keep the secret itself in an environment variable or mounted file:
+
+```yaml
+mcp:
+  server:
+    auth:
+      bootstrap:
+        profiles:
+          - id: shop-staging
+            kind: form
+            allowed-origin: https://shop.example.com
+            credential-reference: env:STAGING_SCAN_PASSWORD
+            login-url: https://shop.example.com/login
+            username: zap-scan-user
+            zap-user-name: zap-scan-user
+            username-field: username
+            password-field: password
+            logged-in-indicator-regex: ".*Logout.*"
+            logged-out-indicator-regex: ".*Sign in.*"
 ```
 
-Allowed credential references use:
+Credential references are exact operator-owned values:
 
 - `env:NAME`
 - `file:/absolute/path`
 
-File wildcard entries are directory containment rules. Sibling-prefix paths and symlink escapes are rejected intentionally.
+Wildcard references and inline secrets are not supported. Use one profile per application, environment, and credential. `allowed-origin` contains only scheme, host, and optional port; paths belong in `targetUrl` and `login-url`.
 
-Inline secrets are disabled by default. Keep them that way outside local, throwaway workflows.
+The ZAP context name is derived from the unique profile ID with an `-auth` suffix. Its scope is the profile's immutable `allowed-origin`, so preparing the same profile for another path cannot rewrite the live scope behind an earlier session or queued job. Different profiles still receive different contexts.
+
+## Upgrade Migration: Profiles Are Explicit
+
+Replace the removed `MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES` and
+`MCP_AUTH_BOOTSTRAP_ALLOW_INLINE_SECRETS` settings. The new profile list defaults
+to empty. A deployment can therefore report healthy while exposing no guided auth
+profiles.
+
+Profiles are compiled only at process startup. After changing profile configuration
+or rotating its secret, restart the MCP process or pod and run the real prepare and
+validate check below. A health check alone is not migration evidence.
+
+The following non-secret profile file is shared by the executable-JAR and Compose
+recipes. Save it as `/etc/mcp-zap/auth-profiles.yml` and adjust the target-specific
+values:
+
+```yaml
+mcp:
+  server:
+    auth:
+      bootstrap:
+        profiles:
+          - id: shop-staging
+            kind: form
+            allowed-origin: https://shop.example.com
+            credential-reference: ${SHOP_SCAN_CREDENTIAL_REFERENCE:env:SHOP_SCAN_PASSWORD}
+            login-url: https://shop.example.com/login
+            username: zap-scan-user
+            username-field: username
+            password-field: password
+            logged-in-indicator-regex: ".*Logout.*"
+            logged-out-indicator-regex: ".*Sign in.*"
+```
+
+### Executable JAR
+
+Inject the password through the existing service manager or secret store. This
+foreground example avoids placing it in shell history:
+
+```bash
+printf 'Shop scan password: ' >&2
+IFS= read -r -s SHOP_SCAN_PASSWORD
+printf '\n' >&2
+export SHOP_SCAN_PASSWORD
+
+./gradlew bootJar
+APP_VERSION=$(./gradlew -q properties | awk '/^version:/ {print $2}')
+java -Dspring.ai.mcp.server.type=sync \
+  -jar "build/libs/mcp-zap-server-${APP_VERSION}.jar" \
+  --spring.config.additional-location=file:/etc/mcp-zap/auth-profiles.yml
+```
+
+Do not make the additional location optional: a missing profile file should fail
+the deployment. Stop and restart the process through its normal supervisor whenever
+the profile or secret changes. Prepared session IDs are in memory and do not survive
+that restart.
+
+### Docker Compose
+
+Keep the password in a host file outside the repository, readable by Docker, and
+use a Compose secret rather than a container environment variable. Create
+`docker-compose.auth-profile.yml` in the repository root:
+
+```yaml
+services:
+  mcp-server:
+    environment:
+      SPRING_CONFIG_ADDITIONAL_LOCATION: file:/app/config/auth-profiles.yml
+      SHOP_SCAN_CREDENTIAL_REFERENCE: file:/run/secrets/shop_scan_password
+    volumes:
+      - ${AUTH_PROFILES_FILE:?set AUTH_PROFILES_FILE}:/app/config/auth-profiles.yml:ro
+    secrets:
+      - shop_scan_password
+
+secrets:
+  shop_scan_password:
+    file: ${SHOP_SCAN_PASSWORD_FILE:?set SHOP_SCAN_PASSWORD_FILE}
+```
+
+Then validate the merged deployment and recreate the MCP container:
+
+```bash
+export AUTH_PROFILES_FILE=/etc/mcp-zap/auth-profiles.yml
+export SHOP_SCAN_PASSWORD_FILE=/run/operator-secrets/shop-staging-password
+test -r "$AUTH_PROFILES_FILE" && test -r "$SHOP_SCAN_PASSWORD_FILE"
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.auth-profile.yml \
+  config --quiet
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.auth-profile.yml \
+  up -d --build --force-recreate --wait --wait-timeout 180 mcp-server
+```
+
+This migration recipe uses the JVM image built by `Dockerfile`; do not add
+`docker-compose.prod.yml`. The native build is not a supported migration path in
+this revision because `nativeCompile` is not configured and its build inputs are
+incomplete. Recreate `mcp-server` after secret-only rotation. The secret target
+must be readable, and the `/zap/wrk` bind mount writable, by runtime UID/GID 1000.
+
+### Helm
+
+Create the Kubernetes Secret from a protected file. The key becomes the environment
+variable referenced by the profile:
+
+```bash
+export NAMESPACE=mcp-zap
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$NAMESPACE" create secret generic mcp-zap-auth-profile \
+  --from-file=SHOP_SCAN_PASSWORD=/run/operator-secrets/shop-staging-password \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Merge this into the values used by the deployment as `auth-profile-values.yml`:
+
+```yaml
+mcp:
+  env:
+    - name: SPRING_APPLICATION_JSON
+      value: |-
+        {
+          "mcp": {
+            "server": {
+              "auth": {
+                "bootstrap": {
+                  "profiles": [{
+                    "id": "shop-staging",
+                    "kind": "form",
+                    "allowedOrigin": "https://shop.example.com",
+                    "credentialReference": "env:SHOP_SCAN_PASSWORD",
+                    "loginUrl": "https://shop.example.com/login",
+                    "username": "zap-scan-user",
+                    "usernameField": "username",
+                    "passwordField": "password",
+                    "loggedInIndicatorRegex": ".*Logout.*",
+                    "loggedOutIndicatorRegex": ".*Sign in.*"
+                  }]
+                }
+              }
+            }
+          }
+        }
+  envFrom:
+    - secretRef:
+        name: mcp-zap-auth-profile
+
+networkPolicy:
+  zap:
+    egress:
+      extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 203.0.113.10/32 # REPLACE with the target's approved CIDR
+          ports:
+            - protocol: TCP
+              port: 443
+```
+
+`mcp.env` and `mcp.envFrom` are lists, so merge any existing entries rather than
+overwriting them. If `SPRING_APPLICATION_JSON` already exists, merge the profile
+object into that value; do not define the variable twice. The default ZAP NetworkPolicy
+permits DNS only, so target egress is mandatory. Private targets also require the
+deployment's explicit URL-policy approval. The commands below force the immutable
+`sha-<40-character commit SHA>` image produced by main CI for the commit containing
+this migration. Replace the variable placeholder before running them. Do not use
+an empty value or `v0.9.1`; either choice deploys code without the profile migration
+contract.
+
+Render before applying, then wait for the MCP rollout:
+
+```bash
+(
+set -euo pipefail
+: "${NAMESPACE:?set NAMESPACE}"
+MCP_ZAP_IMAGE_TAG=sha-REPLACE_WITH_FULL_MAIN_COMMIT_SHA
+[[ "$MCP_ZAP_IMAGE_TAG" =~ ^sha-[0-9a-f]{40}$ ]] || {
+  echo "MCP_ZAP_IMAGE_TAG must be the immutable full-SHA image tag from main CI" >&2
+  exit 1
+}
+
+helm lint helm/mcp-zap-server \
+  -f production-values.yml \
+  -f auth-profile-values.yml \
+  --set-string "mcp.image.tag=$MCP_ZAP_IMAGE_TAG"
+helm template mcp-zap helm/mcp-zap-server \
+  --namespace "$NAMESPACE" \
+  -f production-values.yml \
+  -f auth-profile-values.yml \
+  --set-string "mcp.image.tag=$MCP_ZAP_IMAGE_TAG" \
+  --show-only templates/mcp-deployment.yaml \
+  | grep -E "^[[:space:]]+image: \"[^\"]+:${MCP_ZAP_IMAGE_TAG}\"$" >/dev/null
+helm upgrade --install mcp-zap helm/mcp-zap-server \
+  --namespace "$NAMESPACE" \
+  -f production-values.yml \
+  -f auth-profile-values.yml \
+  --set-string "mcp.image.tag=$MCP_ZAP_IMAGE_TAG" \
+  --atomic --wait
+kubectl -n "$NAMESPACE" rollout status deployment \
+  -l app.kubernetes.io/instance=mcp-zap,app.kubernetes.io/name=mcp-server
+)
+```
+
+A Secret-only update does not change the pod template. Force the required restart:
+
+```bash
+kubectl -n "$NAMESPACE" rollout restart deployment \
+  -l app.kubernetes.io/instance=mcp-zap,app.kubernetes.io/name=mcp-server
+kubectl -n "$NAMESPACE" rollout status deployment \
+  -l app.kubernetes.io/instance=mcp-zap,app.kubernetes.io/name=mcp-server
+```
+
+The chart defaults to a ClusterIP service. After the final rollout, unless you
+already expose it through an approved ingress, keep this port-forward running in a
+second terminal before using the localhost verification URL below:
+
+```bash
+MCP_SERVICE=$(kubectl -n "$NAMESPACE" get service \
+  -l app.kubernetes.io/instance=mcp-zap,app.kubernetes.io/name=mcp-server \
+  -o jsonpath='{.items[0].metadata.name}')
+test -n "$MCP_SERVICE"
+kubectl -n "$NAMESPACE" port-forward "service/$MCP_SERVICE" 7456:7456
+```
+
+### Verify The Migrated Profile
+
+Run this after **every** JAR, Compose, or Helm restart. Use an API key whose client
+has `zap:auth:session:write` and `zap:auth:test`; for JWT mode, set
+`MCP_AUTH_HEADER="Authorization: Bearer $ACCESS_TOKEN"` with those scopes instead.
+The check requires `curl`, `jq`, and standard shell text utilities.
+
+```bash
+(
+set -euo pipefail
+export MCP_URL="${MCP_URL:-http://localhost:7456/mcp}"
+export MCP_AUTH_HEADER="${MCP_AUTH_HEADER:-X-API-Key: ${MCP_API_KEY:?set MCP_API_KEY or MCP_AUTH_HEADER}}"
+export MCP_PROTOCOL_VERSION="${MCP_PROTOCOL_VERSION:-2025-11-25}"
+
+INITIALIZE_REQUEST=$(jq -nc --arg protocolVersion "$MCP_PROTOCOL_VERSION" \
+  '{jsonrpc:"2.0",id:0,method:"initialize",params:{protocolVersion:$protocolVersion,capabilities:{},clientInfo:{name:"auth-profile-check",version:"1.0.0"}}}')
+SESSION_ID=$(curl -si --fail-with-body \
+  -H "$MCP_AUTH_HEADER" \
+  -H 'Accept: application/json,text/event-stream' \
+  -H 'Content-Type: application/json' \
+  "$MCP_URL" \
+  -d "$INITIALIZE_REQUEST" \
+  | awk -F': ' 'tolower($1) == "mcp-session-id" {print $2}' | tr -d '\r')
+test -n "$SESSION_ID"
+
+normalize_mcp_response() {
+  local raw_file=$1
+  local data
+  data=$(sed -n 's/^data:[[:space:]]*//p' "$raw_file" | tail -n 1)
+  if [ -n "$data" ]; then printf '%s' "$data"; else cat "$raw_file"; fi
+}
+
+PREPARE_RAW=$(mktemp)
+VALIDATE_RAW=$(mktemp)
+trap 'rm -f "$PREPARE_RAW" "$VALIDATE_RAW"' EXIT
+
+curl -sS --fail-with-body \
+  -H "$MCP_AUTH_HEADER" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION" \
+  -H 'Accept: application/json,text/event-stream' \
+  -H 'Content-Type: application/json' \
+  "$MCP_URL" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"zap_auth_session_prepare","arguments":{"profileId":"shop-staging","targetUrl":"https://shop.example.com"}}}' \
+  >"$PREPARE_RAW"
+
+PREPARE_JSON=$(normalize_mcp_response "$PREPARE_RAW")
+printf '%s' "$PREPARE_JSON" | jq -e '.result.isError == false' >/dev/null
+PREPARE_TEXT=$(printf '%s' "$PREPARE_JSON" | jq -er '
+  .result.content[] | select(.type == "text") | .text |
+  if startswith("\"") and endswith("\"") then fromjson else . end
+')
+printf '%s\n' "$PREPARE_TEXT" | grep -F 'Guided auth session prepared.'
+printf '%s\n' "$PREPARE_TEXT" | grep -F 'Auth Profile: shop-staging'
+printf '%s\n' "$PREPARE_TEXT" | grep -F 'Authorized Origin: https://shop.example.com'
+AUTH_SESSION_ID=$(printf '%s\n' "$PREPARE_TEXT" | sed -n 's/^Session ID: //p')
+test -n "$AUTH_SESSION_ID"
+
+VALIDATE_REQUEST=$(jq -nc --arg sessionId "$AUTH_SESSION_ID" \
+  '{jsonrpc:"2.0",id:2,method:"tools/call",params:{name:"zap_auth_session_validate",arguments:{sessionId:$sessionId}}}')
+curl -sS --fail-with-body \
+  -H "$MCP_AUTH_HEADER" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -H "MCP-Protocol-Version: $MCP_PROTOCOL_VERSION" \
+  -H 'Accept: application/json,text/event-stream' \
+  -H 'Content-Type: application/json' \
+  "$MCP_URL" -d "$VALIDATE_REQUEST" >"$VALIDATE_RAW"
+
+VALIDATE_JSON=$(normalize_mcp_response "$VALIDATE_RAW")
+printf '%s' "$VALIDATE_JSON" | jq -e '.result.isError == false' >/dev/null
+VALIDATE_TEXT=$(printf '%s' "$VALIDATE_JSON" | jq -er '
+  .result.content[] | select(.type == "text") | .text |
+  if startswith("\"") and endswith("\"") then fromjson else . end
+')
+printf '%s\n' "$VALIDATE_TEXT" | grep -F 'Valid: true'
+printf '%s\n' "$VALIDATE_TEXT" | grep -F 'Outcome: authenticated'
+printf '%s\n' "$VALIDATE_TEXT" | grep -F 'likelyAuthenticated=true'
+)
+```
+
+If any assertion fails, the migration is incomplete. Inspect correlated operator
+logs, fix the profile, secret injection, URL policy, or ZAP egress, restart, and
+repeat. Do not run an authenticated crawl on a health-only or prepare-only signal.
 
 ## Form-login Workflow
 
@@ -48,18 +379,8 @@ Use a dedicated least-privilege scan account and a tight target scope.
 {
   "tool": "zap_auth_session_prepare",
   "arguments": {
-    "targetUrl": "https://shop.example.com",
-    "authKind": "form",
-    "credentialReference": "env:STAGING_SCAN_PASSWORD",
-    "sessionLabel": "shop-staging-form-auth",
-    "contextName": "shop-staging-auth",
-    "loginUrl": "https://shop.example.com/login",
-    "username": "zap-scan-user",
-    "userName": "zap-scan-user",
-    "usernameField": "username",
-    "passwordField": "password",
-    "loggedInIndicatorRegex": ".*Logout.*",
-    "loggedOutIndicatorRegex": ".*Sign in.*"
+    "profileId": "shop-staging",
+    "targetUrl": "https://shop.example.com"
   }
 }
 ```
@@ -67,7 +388,9 @@ Use a dedicated least-privilege scan account and a tight target scope.
 The response should include:
 
 - `Session ID`
+- `Auth Profile: shop-staging`
 - `Auth Kind: form`
+- `Authorized Origin: https://shop.example.com`
 - `Provider: zap-form-login`
 - `Engine Binding: ZAP context/user ready`
 - `Context ID`
@@ -135,10 +458,10 @@ After crawl or attack completion, wait for passive scanning before reading findi
 
 ## Bearer And API-key Sessions
 
-`zap_auth_session_prepare` also accepts:
+Auth profiles also accept:
 
-- `authKind=bearer`
-- `authKind=api-key`
+- `kind: bearer`
+- `kind: api-key`
 
 For those flows, validation proves the credential reference resolves. It does not prove the target accepts the header, and current guided ZAP execution does not automatically inject those headers into crawl or attack execution.
 
@@ -146,16 +469,16 @@ Use bearer and API-key bootstrap for gateway credential-reference preparation to
 
 ## Practical Best Practices
 
-1. Use one prepared session per application, environment, and auth flow.
-2. Prefer `credentialReference` over inline secrets.
-3. Keep `MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES` narrow and operator-owned.
+1. Use one auth profile and prepared session per application, environment, and auth flow.
+2. Keep profile configuration operator-owned and keep raw secrets only in environment variables or mounted files.
+3. Bind every profile to one exact `allowed-origin`.
 4. Use non-admin scan accounts unless admin coverage is explicitly approved.
 5. Validate with `zap_auth_session_validate` before every major scan run.
-6. Treat `likelyAuthenticated=false` as a hard stop.
+6. Treat every `likelyAuthenticated` value other than `true` as a hard stop.
 7. Exclude logout paths and destructive account-management paths from scan scope.
 8. Spider first, then active scan.
 9. Keep scan depth and duration conservative until the target is understood.
-10. Capture `correlationId`, `Session ID`, `Context ID`, and `User ID` as release evidence.
+10. Capture `correlationId`, a SHA-256 fingerprint of the session ID (never the raw ID), `Context ID`, and `User ID` as release evidence.
 
 ## Advanced Expert Workflow
 
@@ -199,10 +522,10 @@ If `zap_auth_test_user` cannot prove the user is authenticated, the scan is not 
 
 ## Common Pitfalls
 
-- `credentialReference is not in the operator allowlist`: the caller selected a secret source operators did not pre-approve.
-- `Provide credentialReference or inlineSecret`: no secret source was supplied.
-- `loginUrl must share the same origin as targetUrl`: form login is trying to cross an origin boundary.
-- `likelyAuthenticated=false`: indicators, field names, credentials, or target behavior are wrong.
+- `Unknown auth profile ID`: the requested profile is not configured.
+- `targetUrl origin is not authorized for auth profile`: the caller tried to use a profile outside its operator-approved origin.
+- `Auth profile ... is invalid`: fix the operator configuration before retrying.
+- `likelyAuthenticated` is not `true`: indicators, field names, credentials, target behavior, or ZAP diagnostics are wrong or indeterminate.
 - Header session validates but crawl is still unauthenticated: bearer/API-key header injection is not in the guided engine path yet.
 - Browser strategy rejects auth: authenticated browser/AJAX guided crawl is not supported yet.
 

--- a/docs/src/content/docs/scanning/mcp-client-scan-to-evidence.md
+++ b/docs/src/content/docs/scanning/mcp-client-scan-to-evidence.md
@@ -78,8 +78,10 @@ For simple auth, prepare and validate a guided auth session:
 1. `zap_auth_session_prepare`
 2. `zap_auth_session_validate`
 
-Use credential references such as `env:NAME` or `file:/absolute/path`. Inline
-secrets should stay disabled except for local throwaway testing.
+Select an operator-managed auth profile and provide a target URL on that
+profile's allowed origin. Profiles hold exact `env:NAME` or
+`file:/absolute/path` credential references; MCP callers never provide secret
+references or inline secrets.
 
 Current guided authenticated crawl and attack support prepared form-login
 sessions. Bearer and API-key session preparation is useful as a contract and
@@ -296,7 +298,7 @@ Not today:
 | Client keeps asking for ZAP scan IDs | It is following expert guidance or old context. | Tell it to follow guided `Next Actions` and use guided operation IDs. |
 | Findings look empty immediately after scan | Passive analysis has not drained. | Run `zap_passive_scan_wait`, then check findings again. |
 | Handoff has caveats | Evidence window is incomplete or direct-only. | Review `zap_scan_history_release_evidence` warnings and rerun with stronger coverage if needed. |
-| Authenticated scan fails | Session target, login indicators, or credential reference is wrong. | Re-run `zap_auth_session_prepare`, then `zap_auth_session_validate`. |
+| Authenticated scan fails | Profile origin, login indicators, or configured credential reference is wrong. | Fix the operator-managed profile, then re-run `zap_auth_session_prepare` and `zap_auth_session_validate`. |
 
 ## Related Docs
 

--- a/src/main/java/mcp/server/zap/core/configuration/AuthBootstrapProperties.java
+++ b/src/main/java/mcp/server/zap/core/configuration/AuthBootstrapProperties.java
@@ -2,6 +2,8 @@ package mcp.server.zap.core.configuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,24 +13,34 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "mcp.server.auth.bootstrap")
 public class AuthBootstrapProperties {
-    private boolean allowInlineSecrets = false;
-    private List<String> allowedCredentialReferences = new ArrayList<>();
+    private List<Profile> profiles = new ArrayList<>();
 
-    public boolean isAllowInlineSecrets() {
-        return allowInlineSecrets;
+    public List<Profile> getProfiles() {
+        return profiles;
     }
 
-    public void setAllowInlineSecrets(boolean allowInlineSecrets) {
-        this.allowInlineSecrets = allowInlineSecrets;
+    public void setProfiles(List<Profile> profiles) {
+        this.profiles = profiles == null ? new ArrayList<>() : new ArrayList<>(profiles);
     }
 
-    public List<String> getAllowedCredentialReferences() {
-        return allowedCredentialReferences;
-    }
-
-    public void setAllowedCredentialReferences(List<String> allowedCredentialReferences) {
-        this.allowedCredentialReferences = allowedCredentialReferences == null
-                ? new ArrayList<>()
-                : new ArrayList<>(allowedCredentialReferences);
+    /**
+     * Operator-owned authentication profile. MCP callers select only the profile ID and target URL;
+     * credential and authentication configuration remain deployment configuration.
+     */
+    @Getter
+    @Setter
+    public static class Profile {
+        private String id;
+        private String kind;
+        private String allowedOrigin;
+        private String credentialReference;
+        private String loginUrl;
+        private String username;
+        private String zapUserName;
+        private String usernameField;
+        private String passwordField;
+        private String headerName;
+        private String loggedInIndicatorRegex;
+        private String loggedOutIndicatorRegex;
     }
 }

--- a/src/main/java/mcp/server/zap/core/service/GuidedAuthSessionMcpToolsService.java
+++ b/src/main/java/mcp/server/zap/core/service/GuidedAuthSessionMcpToolsService.java
@@ -18,40 +18,13 @@ public class GuidedAuthSessionMcpToolsService {
 
     @Tool(
             name = "zap_auth_session_prepare",
-            description = "Prepare a guided auth session for simple form-login, bearer, or api-key flows. Prefer credentialReference values like env:NAME or file:/absolute/path. Inline secrets are disabled by default and should remain local-only."
+            description = "Prepare a guided auth session from an operator-managed profile. The requested target must remain on the profile's authorized origin."
     )
     public String prepareAuthSession(
-            @ToolParam(description = "Target host or base URL for the authenticated flow") String targetUrl,
-            @ToolParam(description = "Auth kind: form, bearer, or api-key") String authKind,
-            @ToolParam(description = "Preferred secret reference such as env:SCAN_PASSWORD or file:/var/run/secrets/scan-password") String credentialReference,
-            @ToolParam(required = false, description = "Optional inline secret. Disabled by default; only use for local self-serve workflows when explicitly enabled.") String inlineSecret,
-            @ToolParam(required = false, description = "Optional session label used to name the prepared session") String sessionLabel,
-            @ToolParam(required = false, description = "Optional context name for form auth flows") String contextName,
-            @ToolParam(required = false, description = "Optional login URL for form auth flows") String loginUrl,
-            @ToolParam(required = false, description = "Optional login username for form auth flows") String username,
-            @ToolParam(required = false, description = "Optional scan user name for form auth flows") String userName,
-            @ToolParam(required = false, description = "Optional username field name for form auth flows (default: username)") String usernameField,
-            @ToolParam(required = false, description = "Optional password field name for form auth flows (default: password)") String passwordField,
-            @ToolParam(required = false, description = "Optional header name for bearer or api-key auth (default: Authorization for bearer, X-API-Key for api-key)") String headerName,
-            @ToolParam(required = false, description = "Optional logged-in indicator regex for form auth flows") String loggedInIndicatorRegex,
-            @ToolParam(required = false, description = "Optional logged-out indicator regex for form auth flows") String loggedOutIndicatorRegex
+            @ToolParam(description = "Operator-configured authentication profile ID") String profileId,
+            @ToolParam(description = "Target URL on the profile's authorized origin; paths may vary") String targetUrl
     ) {
-        return guidedAuthSessionService.prepareSession(
-                targetUrl,
-                authKind,
-                credentialReference,
-                inlineSecret,
-                sessionLabel,
-                contextName,
-                loginUrl,
-                username,
-                userName,
-                usernameField,
-                passwordField,
-                headerName,
-                loggedInIndicatorRegex,
-                loggedOutIndicatorRegex
-        );
+        return guidedAuthSessionService.prepareSession(profileId, targetUrl);
     }
 
     @Tool(

--- a/src/main/java/mcp/server/zap/core/service/GuidedScanWorkflowService.java
+++ b/src/main/java/mcp/server/zap/core/service/GuidedScanWorkflowService.java
@@ -1,7 +1,6 @@
 package mcp.server.zap.core.service;
 
 import java.nio.charset.StandardCharsets;
-import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.util.Base64;
@@ -735,22 +734,18 @@ public class GuidedScanWorkflowService {
                     "Prepared auth session is not bound to a reusable ZAP context/user. Re-run zap_auth_session_prepare for a form-login flow."
             );
         }
-        if (!sameAuthority(targetUrl, session.target().baseUrl())) {
+        if (session.authorizedOrigin() == null) {
             throw new IllegalArgumentException(
-                    "authSessionId target host does not match the requested targetUrl. Reuse the session only on the same app host."
+                    "Prepared auth session has no authorized profile origin. Re-run zap_auth_session_prepare."
+            );
+        }
+        if (!session.authorizedOrigin().matches(session.target().baseUrl())
+                || !session.authorizedOrigin().matches(targetUrl)) {
+            throw new IllegalArgumentException(
+                    "authSessionId is not authorized for the requested targetUrl origin. Reuse the session only on its auth profile origin."
             );
         }
         return session;
-    }
-
-    private boolean sameAuthority(String left, String right) {
-        URI leftUri = URI.create(requireText(left, "targetUrl"));
-        URI rightUri = URI.create(requireText(right, "sessionTargetUrl"));
-        String leftScheme = leftUri.getScheme() == null ? "" : leftUri.getScheme().trim().toLowerCase(Locale.ROOT);
-        String rightScheme = rightUri.getScheme() == null ? "" : rightUri.getScheme().trim().toLowerCase(Locale.ROOT);
-        String leftAuthority = leftUri.getAuthority() == null ? "" : leftUri.getAuthority().trim().toLowerCase(Locale.ROOT);
-        String rightAuthority = rightUri.getAuthority() == null ? "" : rightUri.getAuthority().trim().toLowerCase(Locale.ROOT);
-        return leftScheme.equals(rightScheme) && leftAuthority.equals(rightAuthority);
     }
 
     private record GuidedOperation(

--- a/src/main/java/mcp/server/zap/core/service/UrlValidationService.java
+++ b/src/main/java/mcp/server/zap/core/service/UrlValidationService.java
@@ -77,7 +77,11 @@ public class UrlValidationService {
             throw new IllegalArgumentException("Only HTTP and HTTPS protocols are allowed, got: " + protocol);
         }
 
-        String host = normalizeHost(url.getHost());
+        String originalHost = url.getHost();
+        if (originalHost != null && originalHost.endsWith(".")) {
+            throw new IllegalArgumentException("URL host must not end with a dot");
+        }
+        String host = normalizeHost(originalHost);
         if (host.isEmpty()) {
             throw new IllegalArgumentException("URL must include a valid host");
         }

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/AuthBootstrapRequest.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/AuthBootstrapRequest.java
@@ -4,15 +4,14 @@ package mcp.server.zap.core.service.auth.bootstrap;
  * Gateway request model for guided auth bootstrap preparation.
  */
 public record AuthBootstrapRequest(
-        String sessionLabel,
+        String profileId,
         String targetUrl,
         AuthBootstrapKind authKind,
+        HttpOrigin allowedOrigin,
         String credentialReference,
-        String inlineSecret,
-        String contextName,
         String loginUrl,
         String username,
-        String userName,
+        String zapUserName,
         String usernameField,
         String passwordField,
         String headerName,

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/AuthProfileResolver.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/AuthProfileResolver.java
@@ -1,0 +1,197 @@
+package mcp.server.zap.core.service.auth.bootstrap;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import mcp.server.zap.core.configuration.AuthBootstrapProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves immutable operator-managed authentication profiles for MCP callers.
+ */
+@Component
+public class AuthProfileResolver {
+    private static final int MAX_INDICATOR_REGEX_LENGTH = 512;
+    private static final Pattern PROFILE_ID = Pattern.compile("[A-Za-z0-9._-]{1,64}");
+
+    private final Map<String, ConfiguredAuthProfile> profiles;
+
+    public AuthProfileResolver(AuthBootstrapProperties properties) {
+        this.profiles = compileProfiles(properties == null ? List.of() : properties.getProfiles());
+    }
+
+    public AuthBootstrapRequest resolve(String profileId, String targetUrl) {
+        String normalizedProfileId = requireProfileId(profileId);
+        ConfiguredAuthProfile profile = profiles.get(normalizedProfileId);
+        if (profile == null) {
+            throw new IllegalArgumentException("Unknown auth profile ID: " + normalizedProfileId);
+        }
+        return profile.requestFor(requireText(targetUrl, "targetUrl"));
+    }
+
+    private Map<String, ConfiguredAuthProfile> compileProfiles(List<AuthBootstrapProperties.Profile> configuredProfiles) {
+        Map<String, ConfiguredAuthProfile> compiled = new LinkedHashMap<>();
+        if (configuredProfiles == null) {
+            return Map.of();
+        }
+        for (AuthBootstrapProperties.Profile configured : configuredProfiles) {
+            if (configured == null) {
+                throw new IllegalArgumentException("Auth profile configuration cannot contain null entries");
+            }
+            ConfiguredAuthProfile profile = compileProfile(configured);
+            if (compiled.putIfAbsent(profile.id(), profile) != null) {
+                throw new IllegalArgumentException("Duplicate auth profile ID: " + profile.id());
+            }
+        }
+        return Map.copyOf(compiled);
+    }
+
+    private ConfiguredAuthProfile compileProfile(AuthBootstrapProperties.Profile configured) {
+        String id = requireProfileId(configured.getId());
+        AuthBootstrapKind authKind;
+        try {
+            authKind = AuthBootstrapKind.fromWireValue(configured.getKind());
+        } catch (IllegalArgumentException e) {
+            throw invalidProfile(id, e.getMessage(), e);
+        }
+        HttpOrigin allowedOrigin;
+        try {
+            allowedOrigin = HttpOrigin.fromConfiguredOrigin(configured.getAllowedOrigin());
+        } catch (IllegalArgumentException e) {
+            throw invalidProfile(id, e.getMessage(), e);
+        }
+
+        String credentialReference = requireProfileText(id, configured.getCredentialReference(), "credentialReference");
+        try {
+            CredentialReferenceResolver.validateReference(credentialReference);
+        } catch (IllegalArgumentException e) {
+            throw invalidProfile(id, e.getMessage(), e);
+        }
+        String loginUrl = trimToNull(configured.getLoginUrl());
+        String username = trimToNull(configured.getUsername());
+        String loggedInIndicatorRegex = validateIndicatorRegex(
+                id,
+                configured.getLoggedInIndicatorRegex(),
+                "loggedInIndicatorRegex"
+        );
+        String loggedOutIndicatorRegex = validateIndicatorRegex(
+                id,
+                configured.getLoggedOutIndicatorRegex(),
+                "loggedOutIndicatorRegex"
+        );
+        if (authKind == AuthBootstrapKind.FORM) {
+            loginUrl = requireProfileText(id, loginUrl, "loginUrl");
+            username = requireProfileText(id, username, "username");
+            loggedInIndicatorRegex = requireProfileText(id, loggedInIndicatorRegex, "loggedInIndicatorRegex");
+            try {
+                allowedOrigin.requireMatch(loginUrl, "loginUrl");
+            } catch (IllegalArgumentException e) {
+                throw invalidProfile(id, e.getMessage(), e);
+            }
+        }
+
+        return new ConfiguredAuthProfile(
+                id,
+                authKind,
+                allowedOrigin,
+                credentialReference,
+                loginUrl,
+                username,
+                trimToNull(configured.getZapUserName()),
+                trimToNull(configured.getUsernameField()),
+                trimToNull(configured.getPasswordField()),
+                trimToNull(configured.getHeaderName()),
+                loggedInIndicatorRegex,
+                loggedOutIndicatorRegex
+        );
+    }
+
+    private String validateIndicatorRegex(String profileId, String value, String fieldName) {
+        String regex = trimToNull(value);
+        if (regex == null) {
+            return null;
+        }
+        if (regex.length() > MAX_INDICATOR_REGEX_LENGTH) {
+            throw invalidProfile(
+                    profileId,
+                    fieldName + " cannot exceed " + MAX_INDICATOR_REGEX_LENGTH + " characters"
+            );
+        }
+        try {
+            Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            throw invalidProfile(profileId, fieldName + " must be a valid regular expression", e);
+        }
+        return regex;
+    }
+
+    private String requireProfileId(String value) {
+        String id = requireText(value, "profileId");
+        if (!PROFILE_ID.matcher(id).matches()) {
+            throw new IllegalArgumentException("profileId must use 1-64 letters, numbers, dots, underscores, or dashes");
+        }
+        return id;
+    }
+
+    private String requireProfileText(String profileId, String value, String fieldName) {
+        try {
+            return requireText(value, fieldName);
+        } catch (IllegalArgumentException e) {
+            throw invalidProfile(profileId, e.getMessage(), e);
+        }
+    }
+
+    private IllegalArgumentException invalidProfile(String profileId, String message, Exception cause) {
+        return new IllegalArgumentException("Auth profile '" + profileId + "' is invalid: " + message, cause);
+    }
+
+    private IllegalArgumentException invalidProfile(String profileId, String message) {
+        return new IllegalArgumentException("Auth profile '" + profileId + "' is invalid: " + message);
+    }
+
+    private String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be null or blank");
+        }
+        return value.trim();
+    }
+
+    private String trimToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private record ConfiguredAuthProfile(
+            String id,
+            AuthBootstrapKind authKind,
+            HttpOrigin allowedOrigin,
+            String credentialReference,
+            String loginUrl,
+            String username,
+            String zapUserName,
+            String usernameField,
+            String passwordField,
+            String headerName,
+            String loggedInIndicatorRegex,
+            String loggedOutIndicatorRegex
+    ) {
+        private AuthBootstrapRequest requestFor(String targetUrl) {
+            return new AuthBootstrapRequest(
+                    id,
+                    targetUrl,
+                    authKind,
+                    allowedOrigin,
+                    credentialReference,
+                    loginUrl,
+                    username,
+                    zapUserName,
+                    usernameField,
+                    passwordField,
+                    headerName,
+                    loggedInIndicatorRegex,
+                    loggedOutIndicatorRegex
+            );
+        }
+    }
+}

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/CredentialReferenceResolver.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/CredentialReferenceResolver.java
@@ -4,59 +4,82 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import mcp.server.zap.core.configuration.AuthBootstrapProperties;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
- * Resolves credential references while keeping inline secrets disabled by default.
+ * Resolves the exact environment or file reference held by an operator-managed auth profile.
  */
 @Component
+@Slf4j
 public class CredentialReferenceResolver {
-    private final AuthBootstrapProperties authBootstrapProperties;
+    private static final String CALLER_FAILURE_MESSAGE = "Auth profile credential could not be resolved";
 
-    public CredentialReferenceResolver(AuthBootstrapProperties authBootstrapProperties) {
-        this.authBootstrapProperties = authBootstrapProperties;
-    }
-
-    public String resolveSecret(String credentialReference, String inlineSecret) {
-        if (hasText(credentialReference)) {
-            CredentialReference normalizedReference = normalizeAndAuthorizeReference(credentialReference.trim());
-            return resolveReference(normalizedReference);
+    public String resolveSecret(String credentialReference) {
+        CredentialReference reference;
+        try {
+            reference = normalizeReference(credentialReference);
+        } catch (RuntimeException e) {
+            log.warn("Auth profile credential reference is invalid at runtime");
+            throw callerFailure();
         }
-        if (hasText(inlineSecret)) {
-            if (!authBootstrapProperties.isAllowInlineSecrets()) {
-                throw new IllegalArgumentException(
-                        "inlineSecret is disabled by default. Use credentialReference (env:NAME or file:/abs/path) or explicitly enable mcp.server.auth.bootstrap.allow-inline-secrets for local workflows."
+        if ("env".equals(reference.scheme())) {
+            String value;
+            try {
+                value = System.getenv(reference.envName());
+            } catch (RuntimeException e) {
+                log.error(
+                        "Unable to access auth profile credential environment variable: {}",
+                        reference.envName(),
+                        e
                 );
+                throw callerFailure();
             }
-            return inlineSecret.trim();
+            if (!hasText(value)) {
+                log.warn(
+                        "Auth profile credential environment variable is missing or blank: {}",
+                        reference.envName()
+                );
+                throw callerFailure();
+            }
+            return value.trim();
         }
-        throw new IllegalArgumentException("Provide credentialReference or inlineSecret");
+
+        try {
+            String value = Files.readString(reference.filePath(), StandardCharsets.UTF_8).trim();
+            if (!hasText(value)) {
+                log.warn("Auth profile credential file is empty: {}", reference.filePath());
+                throw callerFailure();
+            }
+            return value;
+        } catch (IOException | SecurityException e) {
+            log.error("Unable to read auth profile credential file: {}", reference.filePath(), e);
+            throw callerFailure();
+        }
     }
 
-    private CredentialReference normalizeAndAuthorizeReference(String credentialReference) {
-        CredentialReference normalizedReference = normalizeReference(credentialReference);
-        if (!isAllowed(normalizedReference)) {
-            throw new IllegalArgumentException(
-                    "credentialReference is not in the operator allowlist"
-            );
-        }
-        return normalizedReference;
+    private IllegalArgumentException callerFailure() {
+        return new IllegalArgumentException(CALLER_FAILURE_MESSAGE);
     }
 
-    private CredentialReference normalizeReference(String credentialReference) {
-        if (credentialReference.startsWith("env:")) {
-            String envName = credentialReference.substring("env:".length()).trim();
+    static void validateReference(String credentialReference) {
+        normalizeReference(credentialReference);
+    }
+
+    private static CredentialReference normalizeReference(String credentialReference) {
+        if (!hasText(credentialReference)) {
+            throw new IllegalArgumentException("Auth profile credentialReference cannot be null or blank");
+        }
+        String value = credentialReference.trim();
+        if (value.startsWith("env:")) {
+            String envName = value.substring("env:".length()).trim();
             if (!hasText(envName)) {
                 throw new IllegalArgumentException("credentialReference env name cannot be blank");
             }
             return CredentialReference.env(envName);
         }
-
-        if (credentialReference.startsWith("file:")) {
-            String rawPath = credentialReference.substring("file:".length()).trim();
+        if (value.startsWith("file:")) {
+            String rawPath = value.substring("file:".length()).trim();
             if (!hasText(rawPath)) {
                 throw new IllegalArgumentException("credentialReference file path cannot be blank");
             }
@@ -66,147 +89,12 @@ public class CredentialReferenceResolver {
             }
             return CredentialReference.file(path.toAbsolutePath().normalize());
         }
-
         throw new IllegalArgumentException(
                 "credentialReference must use env:NAME or file:/absolute/path syntax"
         );
     }
 
-    private boolean isAllowed(CredentialReference normalizedReference) {
-        List<String> allowedReferences = authBootstrapProperties.getAllowedCredentialReferences();
-        if (allowedReferences == null || allowedReferences.isEmpty()) {
-            return false;
-        }
-
-        return allowedReferences.stream()
-                .filter(this::hasText)
-                .map(String::trim)
-                .map(this::normalizeAllowlistEntry)
-                .anyMatch(allowed -> allowlistEntryMatches(allowed, normalizedReference));
-    }
-
-    private AllowlistEntry normalizeAllowlistEntry(String allowedReference) {
-        if (allowedReference.endsWith("*")) {
-            String prefix = allowedReference.substring(0, allowedReference.length() - 1);
-            return normalizeReferencePrefix(prefix);
-        }
-        return AllowlistEntry.exact(normalizeReference(allowedReference));
-    }
-
-    private AllowlistEntry normalizeReferencePrefix(String prefix) {
-        if (prefix.startsWith("env:")) {
-            String envPrefix = prefix.substring("env:".length()).trim();
-            if (!hasText(envPrefix)) {
-                throw new IllegalArgumentException("credentialReference env name cannot be blank");
-            }
-            return AllowlistEntry.env(envPrefix, true);
-        }
-        if (prefix.startsWith("file:")) {
-            String rawPath = prefix.substring("file:".length()).trim();
-            if (!hasText(rawPath)) {
-                throw new IllegalArgumentException("credentialReference file path cannot be blank");
-            }
-            Path path = Path.of(rawPath);
-            if (!path.isAbsolute()) {
-                throw new IllegalArgumentException("credentialReference file path must be absolute");
-            }
-            return AllowlistEntry.file(path.toAbsolutePath().normalize(), true);
-        }
-        throw new IllegalArgumentException(
-                "credentialReference must use env:NAME or file:/absolute/path syntax"
-        );
-    }
-
-    private boolean allowlistEntryMatches(AllowlistEntry allowedReference, CredentialReference normalizedReference) {
-        if (!allowedReference.scheme().equals(normalizedReference.scheme())) {
-            return false;
-        }
-
-        if ("env".equals(normalizedReference.scheme())) {
-            return allowedReference.wildcard()
-                    ? normalizedReference.envName().startsWith(allowedReference.envName())
-                    : normalizedReference.envName().equals(allowedReference.envName());
-        }
-
-        if (!allowedReference.wildcard()) {
-            return sameFileOrNormalized(normalizedReference.filePath(), allowedReference.filePath());
-        }
-        return fileIsInsideDirectory(normalizedReference.filePath(), allowedReference.filePath());
-    }
-
-    private boolean sameFileOrNormalized(Path candidate, Path allowedPath) {
-        return pathForComparison(candidate).equals(pathForComparison(allowedPath));
-    }
-
-    private boolean fileIsInsideDirectory(Path candidate, Path allowedDirectory) {
-        Path candidatePath = pathForComparison(candidate);
-        Path directoryPath = pathForComparison(allowedDirectory);
-        return !candidatePath.equals(directoryPath) && candidatePath.startsWith(directoryPath);
-    }
-
-    private Path pathForComparison(Path path) {
-        try {
-            return path.toRealPath();
-        } catch (IOException ignored) {
-            return bestEffortRealPath(path);
-        }
-    }
-
-    private Path bestEffortRealPath(Path path) {
-        Path absolutePath = path.toAbsolutePath().normalize();
-        Path nearestExistingPath = absolutePath;
-        List<Path> missingSegments = new ArrayList<>();
-
-        while (nearestExistingPath != null && !Files.exists(nearestExistingPath)) {
-            Path fileName = nearestExistingPath.getFileName();
-            if (fileName != null) {
-                missingSegments.add(0, fileName);
-            }
-            nearestExistingPath = nearestExistingPath.getParent();
-        }
-
-        if (nearestExistingPath == null) {
-            return absolutePath;
-        }
-
-        try {
-            Path resolvedPath = nearestExistingPath.toRealPath();
-            for (Path missingSegment : missingSegments) {
-                resolvedPath = resolvedPath.resolve(missingSegment.toString());
-            }
-            return resolvedPath.normalize();
-        } catch (IOException ignored) {
-            return absolutePath;
-        }
-    }
-
-    private String resolveReference(CredentialReference credentialReference) {
-        if ("env".equals(credentialReference.scheme())) {
-            String envName = credentialReference.envName();
-            String value = System.getenv(envName);
-            if (!hasText(value)) {
-                throw new IllegalArgumentException("Environment variable '" + envName + "' is missing or blank");
-            }
-            return value.trim();
-        }
-
-        if ("file".equals(credentialReference.scheme())) {
-            Path path = credentialReference.filePath();
-            try {
-                String value = Files.readString(path, StandardCharsets.UTF_8).trim();
-                if (!hasText(value)) {
-                    throw new IllegalArgumentException("Credential file '" + path + "' is empty");
-                }
-                return value;
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Unable to read credentialReference file '" + path + "'", e);
-            }
-        }
-
-        throw new IllegalArgumentException("credentialReference is not in the operator allowlist");
-    }
-
-    private boolean hasText(String value) {
+    private static boolean hasText(String value) {
         return value != null && !value.isBlank();
     }
 
@@ -217,20 +105,6 @@ public class CredentialReferenceResolver {
 
         private static CredentialReference file(Path filePath) {
             return new CredentialReference("file", null, filePath);
-        }
-    }
-
-    private record AllowlistEntry(String scheme, String envName, Path filePath, boolean wildcard) {
-        private static AllowlistEntry exact(CredentialReference reference) {
-            return new AllowlistEntry(reference.scheme(), reference.envName(), reference.filePath(), false);
-        }
-
-        private static AllowlistEntry env(String envName, boolean wildcard) {
-            return new AllowlistEntry("env", envName, null, wildcard);
-        }
-
-        private static AllowlistEntry file(Path filePath, boolean wildcard) {
-            return new AllowlistEntry("file", null, filePath, wildcard);
         }
     }
 }

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/FormLoginAuthBootstrapProvider.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/FormLoginAuthBootstrapProvider.java
@@ -1,11 +1,9 @@
 package mcp.server.zap.core.service.auth.bootstrap;
 
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -19,6 +17,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
+    private static final String CONTEXT_NAME_SUFFIX = "-auth";
     private static final String DEFAULT_USERNAME_FIELD = "username";
     private static final String DEFAULT_PASSWORD_FIELD = "password";
     private static final String DEFAULT_USER_NAME = "zap-scan-user";
@@ -48,22 +47,23 @@ public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
 
     @Override
     public AuthSessionPrepareResult prepare(AuthBootstrapRequest request) {
+        String profileId = requireText(request.profileId(), "profileId");
         String targetUrl = requireText(request.targetUrl(), "targetUrl");
         String loginUrl = requireText(request.loginUrl(), "loginUrl");
         String username = requireText(request.username(), "username");
         String loggedInIndicatorRegex = requireText(request.loggedInIndicatorRegex(), "loggedInIndicatorRegex");
-        validateUrls(targetUrl, loginUrl);
+        validateUrls(request.allowedOrigin(), targetUrl, loginUrl);
 
-        String contextName = hasText(request.contextName()) ? request.contextName().trim() : deriveContextName(targetUrl);
-        String userName = hasText(request.userName()) ? request.userName().trim() : DEFAULT_USER_NAME;
+        String contextName = profileId + CONTEXT_NAME_SUFFIX;
+        String zapUserName = hasText(request.zapUserName()) ? request.zapUserName().trim() : DEFAULT_USER_NAME;
         String usernameField = hasText(request.usernameField()) ? request.usernameField().trim() : DEFAULT_USERNAME_FIELD;
         String passwordField = hasText(request.passwordField()) ? request.passwordField().trim() : DEFAULT_PASSWORD_FIELD;
         validateFormFieldName(usernameField, "usernameField");
         validateFormFieldName(passwordField, "passwordField");
-        String resolvedSecret = credentialReferenceResolver.resolveSecret(request.credentialReference(), request.inlineSecret());
+        String resolvedSecret = credentialReferenceResolver.resolveSecret(request.credentialReference());
 
-        List<String> includeRegexes = List.of(buildScopeRegex(targetUrl));
-        List<String> excludeRegexes = List.of(buildLogoutRegex(targetUrl));
+        List<String> includeRegexes = List.of(buildScopeRegex(request.allowedOrigin()));
+        List<String> excludeRegexes = List.of(buildLogoutRegex(request.allowedOrigin()));
         Map<String, Object> contextSummary = contextUserService.upsertContext(contextName, includeRegexes, excludeRegexes, true);
         String contextId = stringValue(contextSummary.get("contextId"));
 
@@ -80,19 +80,20 @@ public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
                 + urlEncode(username)
                 + "&password="
                 + urlEncode(resolvedSecret);
-        Map<String, Object> userSummary = contextUserService.upsertUser(contextId, userName, authCredentialsConfigParams, true);
+        Map<String, Object> userSummary = contextUserService.upsertUser(contextId, zapUserName, authCredentialsConfigParams, true);
         String userId = stringValue(userSummary.get("userId"));
 
         PreparedAuthSession session = new PreparedAuthSession(
                 UUID.randomUUID().toString(),
-                defaultSessionLabel(request.sessionLabel(), targetUrl, request.authKind()),
+                profileId,
                 request.authKind(),
                 providerId(),
                 new TargetDescriptor(TargetDescriptor.Kind.WEB, targetUrl, contextName),
+                request.allowedOrigin(),
                 trimToNull(request.credentialReference()),
                 contextName,
                 contextId,
-                userName,
+                zapUserName,
                 userId,
                 null,
                 loginUrl,
@@ -100,9 +101,6 @@ public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
         );
 
         List<String> warnings = new ArrayList<>();
-        if (!hasText(request.credentialReference()) && hasText(request.inlineSecret())) {
-            warnings.add("Inline secret was accepted for this local workflow. Prefer credentialReference for repeatable operator paths.");
-        }
         warnings.add("Run zap_auth_session_validate before authenticated crawl or attack flows.");
 
         return new AuthSessionPrepareResult(session, warnings);
@@ -110,13 +108,14 @@ public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
 
     @Override
     public AuthSessionValidationResult validate(PreparedAuthSession session) {
+        requireSessionOrigin(session);
         Map<String, Object> result = contextUserService.testUserAuthentication(session.contextId(), session.userId());
-        boolean valid = !Boolean.FALSE.equals(result.get("likelyAuthenticated"));
+        boolean valid = Boolean.TRUE.equals(result.get("likelyAuthenticated"));
         List<String> diagnostics = new ArrayList<>();
         diagnostics.add("likelyAuthenticated=" + result.get("likelyAuthenticated"));
         diagnostics.add("contextId=" + session.contextId());
         diagnostics.add("userId=" + session.userId());
-        diagnostics.add("Use zap_context_auth_configure or zap_user_upsert for lower-level fixes if indicators or credentials are wrong.");
+        diagnostics.add("Fix the operator-managed auth profile and re-run zap_auth_session_prepare if indicators or credentials are wrong.");
         return new AuthSessionValidationResult(
                 session,
                 valid,
@@ -125,11 +124,8 @@ public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
         );
     }
 
-    private String buildScopeRegex(String targetUrl) {
-        URI uri = URI.create(targetUrl);
-        String base = uri.getScheme() + "://" + uri.getAuthority();
-        String path = normalizePathPrefix(uri.getPath());
-        return Pattern.quote(base + path) + ".*";
+    private String buildScopeRegex(HttpOrigin allowedOrigin) {
+        return buildOriginRegexPrefix(allowedOrigin) + "(?:[/?#].*)?\\z";
     }
 
     private String buildAuthMethodConfigParams(String loginUrl, String usernameField, String passwordField) {
@@ -154,65 +150,40 @@ public class FormLoginAuthBootstrapProvider implements AuthBootstrapProvider {
         }
     }
 
-    private void validateUrls(String targetUrl, String loginUrl) {
+    private void validateUrls(HttpOrigin allowedOrigin, String targetUrl, String loginUrl) {
+        if (allowedOrigin == null) {
+            throw new IllegalArgumentException("Auth profile allowedOrigin cannot be null");
+        }
         urlValidationService.validateUrl(targetUrl);
         urlValidationService.validateUrl(loginUrl);
+        allowedOrigin.requireMatch(targetUrl, "targetUrl");
+        allowedOrigin.requireMatch(loginUrl, "loginUrl");
+    }
 
-        URI target = URI.create(targetUrl);
-        URI login = URI.create(loginUrl);
-        if (!sameOrigin(target, login)) {
-            throw new IllegalArgumentException("loginUrl must share the same origin as targetUrl");
+    private String buildLogoutRegex(HttpOrigin allowedOrigin) {
+        return buildOriginRegexPrefix(allowedOrigin) + Pattern.quote("/logout") + "(?:[/?#].*)?\\z";
+    }
+
+    private String buildOriginRegexPrefix(HttpOrigin allowedOrigin) {
+        String host = allowedOrigin.host().contains(":")
+                ? "[" + allowedOrigin.host() + "]"
+                : allowedOrigin.host();
+        int defaultPort = "https".equals(allowedOrigin.scheme()) ? 443 : 80;
+        String portRegex = allowedOrigin.port() == defaultPort
+                ? "(?::0*" + defaultPort + ")?"
+                : ":0*" + allowedOrigin.port();
+        return "\\A(?i:"
+                + Pattern.quote(allowedOrigin.scheme() + "://" + host)
+                + ")"
+                + portRegex;
+    }
+
+    private void requireSessionOrigin(PreparedAuthSession session) {
+        if (session.authorizedOrigin() == null) {
+            throw new IllegalArgumentException("Prepared auth session has no authorized profile origin");
         }
-    }
-
-    private boolean sameOrigin(URI target, URI login) {
-        return stringEqualsIgnoreCase(target.getScheme(), login.getScheme())
-                && stringEqualsIgnoreCase(target.getHost(), login.getHost())
-                && effectivePort(target) == effectivePort(login);
-    }
-
-    private int effectivePort(URI uri) {
-        if (uri.getPort() >= 0) {
-            return uri.getPort();
-        }
-        if ("http".equalsIgnoreCase(uri.getScheme())) {
-            return 80;
-        }
-        if ("https".equalsIgnoreCase(uri.getScheme())) {
-            return 443;
-        }
-        return -1;
-    }
-
-    private boolean stringEqualsIgnoreCase(String left, String right) {
-        return left != null && right != null && left.equalsIgnoreCase(right);
-    }
-
-    private String buildLogoutRegex(String targetUrl) {
-        URI uri = URI.create(targetUrl);
-        return Pattern.quote(uri.getScheme() + "://" + uri.getAuthority() + "/logout") + ".*";
-    }
-
-    private String deriveContextName(String targetUrl) {
-        URI uri = URI.create(targetUrl);
-        String host = uri.getHost() == null ? "target" : uri.getHost().toLowerCase(Locale.ROOT).replace('.', '-');
-        return host + "-auth";
-    }
-
-    private String defaultSessionLabel(String sessionLabel, String targetUrl, AuthBootstrapKind authKind) {
-        if (hasText(sessionLabel)) {
-            return sessionLabel.trim();
-        }
-        URI uri = URI.create(targetUrl);
-        String host = uri.getHost() == null ? "target" : uri.getHost().toLowerCase(Locale.ROOT);
-        return host + "-" + authKind.wireValue();
-    }
-
-    private String normalizePathPrefix(String path) {
-        if (!hasText(path) || "/".equals(path)) {
-            return "/";
-        }
-        return path.endsWith("/") ? path : path + "/";
+        session.authorizedOrigin().requireMatch(session.target().baseUrl(), "auth session target");
+        session.authorizedOrigin().requireMatch(session.loginUrl(), "auth session loginUrl");
     }
 
     private String urlEncode(String value) {

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/GuidedAuthSessionService.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/GuidedAuthSessionService.java
@@ -12,44 +12,18 @@ import org.springframework.stereotype.Service;
 public class GuidedAuthSessionService {
     private final List<AuthBootstrapProvider> providers;
     private final PreparedAuthSessionRegistry preparedAuthSessionRegistry;
+    private final AuthProfileResolver authProfileResolver;
 
     public GuidedAuthSessionService(List<AuthBootstrapProvider> providers,
-                                    PreparedAuthSessionRegistry preparedAuthSessionRegistry) {
+                                    PreparedAuthSessionRegistry preparedAuthSessionRegistry,
+                                    AuthProfileResolver authProfileResolver) {
         this.providers = providers;
         this.preparedAuthSessionRegistry = preparedAuthSessionRegistry;
+        this.authProfileResolver = authProfileResolver;
     }
 
-    public String prepareSession(String targetUrl,
-                                 String authKind,
-                                 String credentialReference,
-                                 String inlineSecret,
-                                 String sessionLabel,
-                                 String contextName,
-                                 String loginUrl,
-                                 String username,
-                                 String userName,
-                                 String usernameField,
-                                 String passwordField,
-                                 String headerName,
-                                 String loggedInIndicatorRegex,
-                                 String loggedOutIndicatorRegex) {
-        AuthBootstrapRequest request = new AuthBootstrapRequest(
-                sessionLabel,
-                targetUrl,
-                AuthBootstrapKind.fromWireValue(authKind),
-                trimToNull(credentialReference),
-                trimToNull(inlineSecret),
-                trimToNull(contextName),
-                trimToNull(loginUrl),
-                trimToNull(username),
-                trimToNull(userName),
-                trimToNull(usernameField),
-                trimToNull(passwordField),
-                trimToNull(headerName),
-                trimToNull(loggedInIndicatorRegex),
-                trimToNull(loggedOutIndicatorRegex)
-        );
-
+    public String prepareSession(String profileId, String targetUrl) {
+        AuthBootstrapRequest request = authProfileResolver.resolve(profileId, targetUrl);
         AuthBootstrapProvider provider = resolveProvider(request);
         AuthSessionPrepareResult result = provider.prepare(request);
         PreparedAuthSession session = preparedAuthSessionRegistry.save(result.session());
@@ -57,10 +31,11 @@ public class GuidedAuthSessionService {
         StringBuilder output = new StringBuilder()
                 .append("Guided auth session prepared.\n")
                 .append("Session ID: ").append(session.sessionId()).append('\n')
-                .append("Session Label: ").append(session.sessionLabel()).append('\n')
+                .append("Auth Profile: ").append(session.profileId()).append('\n')
                 .append("Auth Kind: ").append(session.authKind().wireValue()).append('\n')
                 .append("Provider: ").append(session.providerId()).append('\n')
                 .append("Target URL: ").append(session.target().baseUrl()).append('\n')
+                .append("Authorized Origin: ").append(session.authorizedOrigin()).append('\n')
                 .append("Engine Binding: ").append(session.engineBound() ? "ZAP context/user ready" : "gateway contract only").append('\n');
         if (hasText(session.contextName())) {
             output.append("Context Name: ").append(session.contextName()).append('\n');
@@ -68,19 +43,14 @@ public class GuidedAuthSessionService {
         if (hasText(session.contextId())) {
             output.append("Context ID: ").append(session.contextId()).append('\n');
         }
-        if (hasText(session.userName())) {
-            output.append("User Name: ").append(session.userName()).append('\n');
+        if (hasText(session.zapUserName())) {
+            output.append("ZAP User Name: ").append(session.zapUserName()).append('\n');
         }
         if (hasText(session.userId())) {
             output.append("User ID: ").append(session.userId()).append('\n');
         }
         if (hasText(session.headerName())) {
             output.append("Header Name: ").append(session.headerName()).append('\n');
-        }
-        if (hasText(session.credentialReference())) {
-            output.append("Credential Source: ").append(session.credentialReference()).append('\n');
-        } else {
-            output.append("Credential Source: inline-secret\n");
         }
         output.append("Next Step: call zap_auth_session_validate with this session ID before running authenticated crawl or attack flows.");
 
@@ -156,10 +126,6 @@ public class GuidedAuthSessionService {
             throw new IllegalArgumentException(fieldName + " cannot be null or blank");
         }
         return value.trim();
-    }
-
-    private String trimToNull(String value) {
-        return hasText(value) ? value.trim() : null;
     }
 
     private boolean hasText(String value) {

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/HeaderCredentialAuthBootstrapProvider.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/HeaderCredentialAuthBootstrapProvider.java
@@ -1,9 +1,7 @@
 package mcp.server.zap.core.service.auth.bootstrap;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
 import mcp.server.zap.core.gateway.TargetDescriptor;
 import mcp.server.zap.core.service.UrlValidationService;
@@ -35,16 +33,22 @@ public class HeaderCredentialAuthBootstrapProvider implements AuthBootstrapProvi
 
     @Override
     public AuthSessionPrepareResult prepare(AuthBootstrapRequest request) {
+        String profileId = requireText(request.profileId(), "profileId");
         String targetUrl = requireText(request.targetUrl(), "targetUrl");
         urlValidationService.validateUrl(targetUrl);
-        credentialReferenceResolver.resolveSecret(request.credentialReference(), request.inlineSecret());
+        if (request.allowedOrigin() == null) {
+            throw new IllegalArgumentException("Auth profile allowedOrigin cannot be null");
+        }
+        request.allowedOrigin().requireMatch(targetUrl, "targetUrl");
+        credentialReferenceResolver.resolveSecret(request.credentialReference());
 
         PreparedAuthSession session = new PreparedAuthSession(
                 UUID.randomUUID().toString(),
-                defaultSessionLabel(request.sessionLabel(), targetUrl, request.authKind()),
+                profileId,
                 request.authKind(),
                 providerId(),
                 new TargetDescriptor(TargetDescriptor.Kind.API, targetUrl, targetUrl),
+                request.allowedOrigin(),
                 trimToNull(request.credentialReference()),
                 null,
                 null,
@@ -56,9 +60,6 @@ public class HeaderCredentialAuthBootstrapProvider implements AuthBootstrapProvi
         );
 
         List<String> warnings = new ArrayList<>();
-        if (!hasText(request.credentialReference()) && hasText(request.inlineSecret())) {
-            warnings.add("Inline secret was accepted for this local workflow. Prefer credentialReference for repeatable operator paths.");
-        }
         warnings.add("Current guided ZAP flows do not automatically inject header-based auth yet. This session is stored as a gateway contract and validation scaffold.");
 
         return new AuthSessionPrepareResult(session, warnings);
@@ -66,18 +67,11 @@ public class HeaderCredentialAuthBootstrapProvider implements AuthBootstrapProvi
 
     @Override
     public AuthSessionValidationResult validate(PreparedAuthSession session) {
-        if (!hasText(session.credentialReference())) {
-            return new AuthSessionValidationResult(
-                    session,
-                    false,
-                    "reference_missing",
-                    List.of(
-                            "This session was prepared from an inline secret and cannot be revalidated without re-preparing it.",
-                            "Prefer credentialReference values like env:NAME or file:/absolute/path for repeatable operator workflows."
-                    )
-            );
+        if (session.authorizedOrigin() == null) {
+            throw new IllegalArgumentException("Prepared auth session has no authorized profile origin");
         }
-        credentialReferenceResolver.resolveSecret(session.credentialReference(), null);
+        session.authorizedOrigin().requireMatch(session.target().baseUrl(), "auth session target");
+        credentialReferenceResolver.resolveSecret(session.credentialReference());
         List<String> diagnostics = new ArrayList<>();
         diagnostics.add("credentialReference resolved successfully");
         diagnostics.add("headerName=" + session.headerName());
@@ -92,15 +86,6 @@ public class HeaderCredentialAuthBootstrapProvider implements AuthBootstrapProvi
 
     private String defaultHeaderName(AuthBootstrapKind authKind) {
         return authKind == AuthBootstrapKind.BEARER ? "Authorization" : "X-API-Key";
-    }
-
-    private String defaultSessionLabel(String sessionLabel, String targetUrl, AuthBootstrapKind authKind) {
-        if (hasText(sessionLabel)) {
-            return sessionLabel.trim();
-        }
-        URI uri = URI.create(targetUrl);
-        String host = uri.getHost() == null ? "target" : uri.getHost().toLowerCase(Locale.ROOT);
-        return host + "-" + authKind.wireValue();
     }
 
     private String requireText(String value, String fieldName) {

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/HttpOrigin.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/HttpOrigin.java
@@ -1,0 +1,109 @@
+package mcp.server.zap.core.service.auth.bootstrap;
+
+import java.net.IDN;
+import java.net.URI;
+import java.util.Locale;
+
+/**
+ * Canonical HTTP origin used to bind an operator-managed credential to one relying party.
+ */
+public record HttpOrigin(String scheme, String host, int port) {
+
+    public HttpOrigin {
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            throw new IllegalArgumentException("scheme must be http or https");
+        }
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("host cannot be null or blank");
+        }
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("port must be between 1 and 65535");
+        }
+    }
+
+    public static HttpOrigin fromConfiguredOrigin(String value) {
+        URI uri = parse(value, "allowedOrigin");
+        String path = uri.getRawPath();
+        if ((path != null && !path.isBlank() && !"/".equals(path))
+                || uri.getRawQuery() != null
+                || uri.getRawFragment() != null) {
+            throw new IllegalArgumentException("allowedOrigin must contain only scheme, host, and optional port");
+        }
+        return fromUri(uri, "allowedOrigin");
+    }
+
+    public static HttpOrigin fromUrl(String value) {
+        return fromUri(parse(value, "URL"), "URL");
+    }
+
+    public boolean matches(String url) {
+        return equals(fromUrl(url));
+    }
+
+    public void requireMatch(String url, String fieldName) {
+        if (!matches(url)) {
+            throw new IllegalArgumentException(fieldName + " origin is not authorized for auth profile");
+        }
+    }
+
+    @Override
+    public String toString() {
+        String formattedHost = host.contains(":") ? "[" + host + "]" : host;
+        int defaultPort = "https".equals(scheme) ? 443 : 80;
+        return scheme + "://" + formattedHost + (port == defaultPort ? "" : ":" + port);
+    }
+
+    private static URI parse(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be null or blank");
+        }
+        try {
+            return URI.create(value.trim());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(fieldName + " must be a valid absolute HTTP(S) URL", e);
+        }
+    }
+
+    private static HttpOrigin fromUri(URI uri, String fieldName) {
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            throw new IllegalArgumentException(fieldName + " must use http or https");
+        }
+        if (uri.isOpaque() || uri.getRawUserInfo() != null) {
+            throw new IllegalArgumentException(fieldName + " must not contain user information");
+        }
+        if (uri.getPort() < 0
+                && uri.getRawAuthority() != null
+                && uri.getRawAuthority().endsWith(":")) {
+            throw new IllegalArgumentException(fieldName + " port cannot be empty");
+        }
+
+        String host = normalizeHost(uri.getHost(), fieldName);
+        int port = uri.getPort();
+        if (port < 0) {
+            port = "https".equals(scheme) ? 443 : 80;
+        }
+        return new HttpOrigin(scheme, host, port);
+    }
+
+    private static String normalizeHost(String rawHost, String fieldName) {
+        if (rawHost == null || rawHost.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must include a host");
+        }
+        String host = rawHost.trim();
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
+        if (host.endsWith(".")) {
+            throw new IllegalArgumentException(fieldName + " host must not end with a dot");
+        }
+        if (host.contains(":")) {
+            return host.toLowerCase(Locale.ROOT);
+        }
+        try {
+            return IDN.toASCII(host, IDN.USE_STD3_ASCII_RULES).toLowerCase(Locale.ROOT);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(fieldName + " host is invalid", e);
+        }
+    }
+}

--- a/src/main/java/mcp/server/zap/core/service/auth/bootstrap/PreparedAuthSession.java
+++ b/src/main/java/mcp/server/zap/core/service/auth/bootstrap/PreparedAuthSession.java
@@ -7,14 +7,15 @@ import mcp.server.zap.core.gateway.TargetDescriptor;
  */
 public record PreparedAuthSession(
         String sessionId,
-        String sessionLabel,
+        String profileId,
         AuthBootstrapKind authKind,
         String providerId,
         TargetDescriptor target,
+        HttpOrigin authorizedOrigin,
         String credentialReference,
         String contextName,
         String contextId,
-        String userName,
+        String zapUserName,
         String userId,
         String headerName,
         String loginUrl,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,8 +79,9 @@ mcp:
             table-name: ${JWT_REVOCATION_STORE_POSTGRES_TABLE_NAME:jwt_token_revocation}
             fail-fast: ${JWT_REVOCATION_STORE_POSTGRES_FAIL_FAST:false}
       bootstrap:
-        allowInlineSecrets: ${MCP_AUTH_BOOTSTRAP_ALLOW_INLINE_SECRETS:false}
-        allowedCredentialReferences: ${MCP_AUTH_BOOTSTRAP_ALLOWED_CREDENTIAL_REFERENCES:}
+        # Profiles are operator-owned configuration. Each profile binds one exact credential
+        # reference to one canonical HTTP(S) origin; callers provide only profileId + targetUrl.
+        profiles: []
     protection:
       enabled: ${MCP_PROTECTION_ENABLED:true}
       retryAfterSeconds: ${MCP_PROTECTION_RETRY_AFTER_SECONDS:30}

--- a/src/test/java/mcp/server/zap/architecture/DockerImagePackagingArchitectureTest.java
+++ b/src/test/java/mcp/server/zap/architecture/DockerImagePackagingArchitectureTest.java
@@ -22,12 +22,18 @@ class DockerImagePackagingArchitectureTest {
                 .contains("gradle bootJar -x test")
                 .contains("Expected exactly one executable application JAR")
                 .contains("cp \"${boot_jars}\" /tmp/app.jar")
-                .contains("COPY --from=builder /tmp/app.jar ./app.jar")
+                .contains("addgroup -S -g 1000 app")
+                .contains("adduser -S -D -H -u 1000 -G app app")
+                .contains("mkdir -p /app /zap/wrk")
+                .contains("chown -R 1000:1000 /app /zap/wrk")
+                .contains("COPY --chown=1000:1000 --from=builder /tmp/app.jar ./app.jar")
+                .contains("USER 1000:1000")
                 .contains("! -name '*-plain.jar'")
                 .contains("! -name '*-enterprise-extension.jar'")
                 .contains("! -name '*-sample-policy-metadata-extension.jar'")
                 .contains("! -name 'mcp-zap-extension-api-*.jar'")
                 .doesNotContain("COPY --from=builder /usr/src/app/build/libs/*.jar ./app.jar")
-                .doesNotContain("COPY --from=builder /usr/src/app/build/libs/mcp-zap-server-*.jar ./app.jar");
+                .doesNotContain("COPY --from=builder /usr/src/app/build/libs/mcp-zap-server-*.jar ./app.jar")
+                .doesNotContain("USER root");
     }
 }

--- a/src/test/java/mcp/server/zap/core/service/GuidedAuthSessionMcpToolsServiceTest.java
+++ b/src/test/java/mcp/server/zap/core/service/GuidedAuthSessionMcpToolsServiceTest.java
@@ -1,0 +1,37 @@
+package mcp.server.zap.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import mcp.server.zap.core.service.auth.bootstrap.GuidedAuthSessionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.annotation.Tool;
+
+class GuidedAuthSessionMcpToolsServiceTest {
+
+    @Test
+    void prepareSurfaceAcceptsOnlyProfileAndPolicyVisibleTarget() {
+        var prepareTools = Arrays.stream(GuidedAuthSessionMcpToolsService.class.getDeclaredMethods())
+                .filter(method -> method.isAnnotationPresent(Tool.class))
+                .filter(method -> "zap_auth_session_prepare".equals(method.getAnnotation(Tool.class).name()))
+                .toList();
+        assertThat(prepareTools).hasSize(1);
+        assertThat(prepareTools.get(0).getParameters())
+                .extracting(Parameter::getName)
+                .containsExactly("profileId", "targetUrl");
+
+        GuidedAuthSessionService authSessionService = mock(GuidedAuthSessionService.class);
+        GuidedAuthSessionMcpToolsService tools = new GuidedAuthSessionMcpToolsService(authSessionService);
+        when(authSessionService.prepareSession("shop-staging", "https://shop.example.com/admin"))
+                .thenReturn("prepared");
+
+        String response = tools.prepareAuthSession("shop-staging", "https://shop.example.com/admin");
+
+        assertThat(response).isEqualTo("prepared");
+        verify(authSessionService).prepareSession("shop-staging", "https://shop.example.com/admin");
+    }
+}

--- a/src/test/java/mcp/server/zap/core/service/GuidedSecurityToolsServiceTest.java
+++ b/src/test/java/mcp/server/zap/core/service/GuidedSecurityToolsServiceTest.java
@@ -14,6 +14,7 @@ import mcp.server.zap.core.gateway.UnsupportedEngineCapabilityException;
 import mcp.server.zap.core.gateway.ZapEngineAdapter;
 import mcp.server.zap.core.service.auth.bootstrap.AuthBootstrapKind;
 import mcp.server.zap.core.service.auth.bootstrap.GuidedAuthSessionService;
+import mcp.server.zap.core.service.auth.bootstrap.HttpOrigin;
 import mcp.server.zap.core.service.auth.bootstrap.PreparedAuthSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class GuidedSecurityToolsServiceTest {
@@ -348,6 +350,30 @@ class GuidedSecurityToolsServiceTest {
     }
 
     @Test
+    void preparedProfileCannotBeReusedForCrawlOnAnotherOrigin() {
+        PreparedAuthSession session = preparedFormSession("auth-crawl", "https://app.example.com", "1", "7");
+        when(guidedAuthSessionService.getPreparedSession("auth-crawl")).thenReturn(session);
+
+        assertThatThrownBy(() -> service.startCrawl("https://attacker.example", "http", null, "auth-crawl"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not authorized for the requested targetUrl origin");
+
+        verifyNoInteractions(spiderScanService, scanJobQueueService);
+    }
+
+    @Test
+    void preparedProfileCannotBeReusedForAttackOnAnotherOrigin() {
+        PreparedAuthSession session = preparedFormSession("auth-attack", "https://app.example.com", "1", "7");
+        when(guidedAuthSessionService.getPreparedSession("auth-attack")).thenReturn(session);
+
+        assertThatThrownBy(() -> service.startAttack("https://attacker.example", "true", "Baseline", null, "auth-attack"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not authorized for the requested targetUrl origin");
+
+        verifyNoInteractions(activeScanService, scanJobQueueService);
+    }
+
+    @Test
     void startCrawlRejectsBrowserStrategyWhenAuthSessionProvided() {
         PreparedAuthSession session = preparedFormSession("auth-3", "https://app.example.com", "1", "7");
         when(guidedAuthSessionService.getPreparedSession("auth-3")).thenReturn(session);
@@ -365,6 +391,7 @@ class GuidedSecurityToolsServiceTest {
                 AuthBootstrapKind.API_KEY,
                 "gateway-header-reference",
                 new TargetDescriptor(TargetDescriptor.Kind.API, "https://api.example.com", "https://api.example.com"),
+                HttpOrigin.fromConfiguredOrigin("https://api.example.com"),
                 "env:ORDERS_API_KEY",
                 null,
                 null,
@@ -637,6 +664,7 @@ class GuidedSecurityToolsServiceTest {
                 AuthBootstrapKind.FORM,
                 "zap-form-login",
                 new TargetDescriptor(TargetDescriptor.Kind.WEB, targetUrl, "shop-auth"),
+                HttpOrigin.fromUrl(targetUrl),
                 "env:SHOP_PASSWORD",
                 "shop-auth",
                 contextId,

--- a/src/test/java/mcp/server/zap/core/service/UrlValidationServiceTest.java
+++ b/src/test/java/mcp/server/zap/core/service/UrlValidationServiceTest.java
@@ -50,6 +50,16 @@ class UrlValidationServiceTest {
     }
 
     @Test
+    void rejectsTerminalDotBeforePolicyResolution() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.validateUrl("https://example.com./account")
+        );
+
+        assertEquals("URL host must not end with a dot", exception.getMessage());
+    }
+
+    @Test
     void rejectsLocalhostByDefault() {
         assertThrows(IllegalArgumentException.class, () -> service.validateUrl("http://localhost"));
         assertThrows(IllegalArgumentException.class, () -> service.validateUrl("http://127.0.0.1"));

--- a/src/test/java/mcp/server/zap/core/service/auth/bootstrap/AuthProfileResolverTest.java
+++ b/src/test/java/mcp/server/zap/core/service/auth/bootstrap/AuthProfileResolverTest.java
@@ -1,0 +1,151 @@
+package mcp.server.zap.core.service.auth.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import mcp.server.zap.core.configuration.AuthBootstrapProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+class AuthProfileResolverTest {
+
+    @Test
+    void resolvesOperatorFieldsAndCallerTargetAsOneRequest() {
+        AuthProfileResolver resolver = new AuthProfileResolver(propertiesWith(formProfile("shop-staging")));
+
+        AuthBootstrapRequest request = resolver.resolve(
+                "shop-staging",
+                "https://shop.example.com/catalog"
+        );
+
+        assertThat(request.profileId()).isEqualTo("shop-staging");
+        assertThat(request.authKind()).isEqualTo(AuthBootstrapKind.FORM);
+        assertThat(request.allowedOrigin()).isEqualTo(HttpOrigin.fromConfiguredOrigin("https://shop.example.com"));
+        assertThat(request.targetUrl()).isEqualTo("https://shop.example.com/catalog");
+        assertThat(request.loginUrl()).isEqualTo("https://shop.example.com/login");
+        assertThat(request.credentialReference()).isEqualTo("env:SHOP_PASSWORD");
+    }
+
+    @Test
+    void rejectsUnknownAndDuplicateProfiles() {
+        AuthProfileResolver resolver = new AuthProfileResolver(propertiesWith(formProfile("shop-staging")));
+
+        assertThatThrownBy(() -> resolver.resolve("missing", "https://shop.example.com"))
+                .hasMessage("Unknown auth profile ID: missing");
+
+        AuthBootstrapProperties duplicateProperties = propertiesWith(
+                formProfile("shop-staging"),
+                formProfile("shop-staging")
+        );
+        assertThatThrownBy(() -> new AuthProfileResolver(duplicateProperties))
+                .hasMessage("Duplicate auth profile ID: shop-staging");
+    }
+
+    @Test
+    void rejectsProfileWhoseLoginIsOutsideItsAllowedOrigin() {
+        AuthBootstrapProperties.Profile profile = formProfile("shop-staging");
+        profile.setLoginUrl("https://attacker.example/login");
+
+        assertThatThrownBy(() -> new AuthProfileResolver(propertiesWith(profile)))
+                .hasMessageContaining("Auth profile 'shop-staging' is invalid")
+                .hasMessageContaining("loginUrl origin is not authorized for auth profile");
+    }
+
+    @Test
+    void rejectsInvalidCredentialReferenceBeforeProfileCanBeSelected() {
+        AuthBootstrapProperties.Profile profile = formProfile("shop-staging");
+        profile.setCredentialReference("file:relative/secret");
+
+        assertThatThrownBy(() -> new AuthProfileResolver(propertiesWith(profile)))
+                .hasMessageContaining("Auth profile 'shop-staging' is invalid")
+                .hasMessageContaining("credentialReference file path must be absolute");
+    }
+
+    @Test
+    void rejectsMalformedIndicatorRegexesWhenProfilesAreCompiled() {
+        AuthBootstrapProperties.Profile loggedIn = formProfile("bad-logged-in");
+        loggedIn.setLoggedInIndicatorRegex("[");
+        assertThatThrownBy(() -> new AuthProfileResolver(propertiesWith(loggedIn)))
+                .hasMessageContaining("Auth profile 'bad-logged-in' is invalid")
+                .hasMessageContaining("loggedInIndicatorRegex must be a valid regular expression");
+
+        AuthBootstrapProperties.Profile loggedOut = formProfile("bad-logged-out");
+        loggedOut.setLoggedOutIndicatorRegex("[");
+        assertThatThrownBy(() -> new AuthProfileResolver(propertiesWith(loggedOut)))
+                .hasMessageContaining("Auth profile 'bad-logged-out' is invalid")
+                .hasMessageContaining("loggedOutIndicatorRegex must be a valid regular expression");
+    }
+
+    @Test
+    void rejectsIndicatorRegexesLongerThanTheRuntimeLimit() {
+        AuthBootstrapProperties.Profile loggedIn = formProfile("long-logged-in");
+        loggedIn.setLoggedInIndicatorRegex("a".repeat(513));
+        assertThatThrownBy(() -> new AuthProfileResolver(propertiesWith(loggedIn)))
+                .hasMessageContaining("loggedInIndicatorRegex cannot exceed 512 characters");
+
+        AuthBootstrapProperties.Profile loggedOut = formProfile("long-logged-out");
+        loggedOut.setLoggedOutIndicatorRegex("a".repeat(513));
+        assertThatThrownBy(() -> new AuthProfileResolver(propertiesWith(loggedOut)))
+                .hasMessageContaining("loggedOutIndicatorRegex cannot exceed 512 characters");
+    }
+
+    @Test
+    void acceptsIndicatorRegexesAtTheRuntimeLengthLimit() {
+        AuthBootstrapProperties.Profile profile = formProfile("limit");
+        profile.setLoggedInIndicatorRegex("a".repeat(512));
+        profile.setLoggedOutIndicatorRegex("b".repeat(512));
+
+        AuthBootstrapRequest request = new AuthProfileResolver(propertiesWith(profile))
+                .resolve("limit", "https://shop.example.com");
+
+        assertThat(request.loggedInIndicatorRegex()).hasSize(512);
+        assertThat(request.loggedOutIndicatorRegex()).hasSize(512);
+    }
+
+    @Test
+    void springConfigurationBindingBuildsIndexedProfile() {
+        MapConfigurationPropertySource source = new MapConfigurationPropertySource(Map.of(
+                "mcp.server.auth.bootstrap.profiles[0].id", "shop-staging",
+                "mcp.server.auth.bootstrap.profiles[0].kind", "form",
+                "mcp.server.auth.bootstrap.profiles[0].allowed-origin", "https://shop.example.com",
+                "mcp.server.auth.bootstrap.profiles[0].credential-reference", "env:SHOP_PASSWORD",
+                "mcp.server.auth.bootstrap.profiles[0].login-url", "https://shop.example.com/login",
+                "mcp.server.auth.bootstrap.profiles[0].username", "zap-scan-user",
+                "mcp.server.auth.bootstrap.profiles[0].zap-user-name", "shop-zap-user",
+                "mcp.server.auth.bootstrap.profiles[0].logged-in-indicator-regex", ".*Logout.*"
+        ));
+        AuthBootstrapProperties properties = new Binder(source)
+                .bind("mcp.server.auth.bootstrap", Bindable.of(AuthBootstrapProperties.class))
+                .orElseThrow(() -> new AssertionError("Expected auth bootstrap properties to bind"));
+
+        AuthBootstrapRequest request = new AuthProfileResolver(properties)
+                .resolve("shop-staging", "https://shop.example.com/account");
+
+        assertThat(request.profileId()).isEqualTo("shop-staging");
+        assertThat(request.allowedOrigin().toString()).isEqualTo("https://shop.example.com");
+        assertThat(request.loginUrl()).isEqualTo("https://shop.example.com/login");
+        assertThat(request.zapUserName()).isEqualTo("shop-zap-user");
+    }
+
+    private AuthBootstrapProperties propertiesWith(AuthBootstrapProperties.Profile... profiles) {
+        AuthBootstrapProperties properties = new AuthBootstrapProperties();
+        properties.setProfiles(List.of(profiles));
+        return properties;
+    }
+
+    private AuthBootstrapProperties.Profile formProfile(String id) {
+        AuthBootstrapProperties.Profile profile = new AuthBootstrapProperties.Profile();
+        profile.setId(id);
+        profile.setKind("form");
+        profile.setAllowedOrigin("https://shop.example.com");
+        profile.setCredentialReference("env:SHOP_PASSWORD");
+        profile.setLoginUrl("https://shop.example.com/login");
+        profile.setUsername("zap-scan-user");
+        profile.setLoggedInIndicatorRegex(".*Logout.*");
+        return profile;
+    }
+}

--- a/src/test/java/mcp/server/zap/core/service/auth/bootstrap/CredentialReferenceResolverTest.java
+++ b/src/test/java/mcp/server/zap/core/service/auth/bootstrap/CredentialReferenceResolverTest.java
@@ -2,68 +2,91 @@ package mcp.server.zap.core.service.auth.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.IOException;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import mcp.server.zap.core.configuration.AuthBootstrapProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 class CredentialReferenceResolverTest {
     @TempDir
     private Path tempDir;
 
-    @Test
-    void fileWildcardAllowsChildPath() throws Exception {
-        Path allowedDirectory = Files.createDirectories(tempDir.resolve("mcp-zap"));
-        Path token = allowedDirectory.resolve("token");
-        Files.writeString(token, "child-secret\n");
+    private final CredentialReferenceResolver resolver = new CredentialReferenceResolver();
+    private Logger resolverLogger;
+    private ListAppender<ILoggingEvent> logAppender;
 
-        CredentialReferenceResolver resolver = resolverAllowing("file:" + allowedDirectory + "/*");
+    @BeforeEach
+    void attachLogAppender() {
+        resolverLogger = (Logger) LoggerFactory.getLogger(CredentialReferenceResolver.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        resolverLogger.addAppender(logAppender);
+    }
 
-        assertThat(resolver.resolveSecret("file:" + token, null)).isEqualTo("child-secret");
+    @AfterEach
+    void detachLogAppender() {
+        resolverLogger.detachAppender(logAppender);
+        logAppender.stop();
     }
 
     @Test
-    void fileWildcardRejectsSiblingPrefixPath() throws Exception {
-        Path allowedDirectory = Files.createDirectories(tempDir.resolve("mcp-zap"));
-        Path siblingDirectory = Files.createDirectories(tempDir.resolve("mcp-zap-prod"));
-        Path token = siblingDirectory.resolve("token");
-        Files.writeString(token, "sibling-secret\n");
+    void resolvesExactFileReferenceFromOperatorProfile() throws Exception {
+        Path token = tempDir.resolve("token");
+        Files.writeString(token, "profile-secret\n");
 
-        CredentialReferenceResolver resolver = resolverAllowing("file:" + allowedDirectory + "/*");
+        assertThat(resolver.resolveSecret("file:" + token)).isEqualTo("profile-secret");
+    }
 
-        assertThatThrownBy(() -> resolver.resolveSecret("file:" + token, null))
+    @Test
+    void sanitizesInvalidRuntimeReference() {
+        assertThatThrownBy(() -> resolver.resolveSecret("file:relative/token"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("credentialReference is not in the operator allowlist");
+                .hasMessage("Auth profile credential could not be resolved")
+                .hasNoCause();
     }
 
     @Test
-    void fileWildcardRejectsSymlinkEscape() throws Exception {
-        Path allowedDirectory = Files.createDirectories(tempDir.resolve("mcp-zap"));
-        Path outsideDirectory = Files.createDirectories(tempDir.resolve("outside"));
-        Path outsideToken = outsideDirectory.resolve("token");
-        Files.writeString(outsideToken, "outside-secret\n");
-        Path symlink = allowedDirectory.resolve("linked-token");
-        try {
-            Files.createSymbolicLink(symlink, outsideToken);
-        } catch (IOException | UnsupportedOperationException e) {
-            assumeTrue(false, "symbolic links are not available on this filesystem");
-        }
+    void rejectsWildcardReferenceEvenWhenMatchingFileExists() throws Exception {
+        Files.writeString(tempDir.resolve("matching-secret"), "secret");
 
-        CredentialReferenceResolver resolver = resolverAllowing("file:" + allowedDirectory + "/*");
-
-        assertThatThrownBy(() -> resolver.resolveSecret("file:" + symlink, null))
+        assertThatThrownBy(() -> resolver.resolveSecret("file:" + tempDir + "/*"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("credentialReference is not in the operator allowlist");
+                .hasMessage("Auth profile credential could not be resolved")
+                .hasNoCause();
     }
 
-    private CredentialReferenceResolver resolverAllowing(String allowedReference) {
-        AuthBootstrapProperties properties = new AuthBootstrapProperties();
-        properties.setAllowedCredentialReferences(List.of(allowedReference));
-        return new CredentialReferenceResolver(properties);
+    @Test
+    void missingEnvironmentIsDetailedOnlyInOperatorLogs() {
+        String envName = "MCP_ZAP_AUTH_PROFILE_TEST_MISSING";
+
+        assertThatThrownBy(() -> resolver.resolveSecret("env:" + envName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Auth profile credential could not be resolved")
+                .hasNoCause();
+
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message).contains(envName));
+    }
+
+    @Test
+    void missingFileIsDetailedOnlyInOperatorLogs() {
+        Path missingFile = tempDir.resolve("operator-only-path");
+
+        assertThatThrownBy(() -> resolver.resolveSecret("file:" + missingFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Auth profile credential could not be resolved")
+                .hasNoCause();
+
+        assertThat(logAppender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message).contains(missingFile.toString()));
     }
 }

--- a/src/test/java/mcp/server/zap/core/service/auth/bootstrap/GuidedAuthSessionServiceTest.java
+++ b/src/test/java/mcp/server/zap/core/service/auth/bootstrap/GuidedAuthSessionServiceTest.java
@@ -1,6 +1,16 @@
 package mcp.server.zap.core.service.auth.bootstrap;
 
-import java.net.URI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -14,15 +24,7 @@ import mcp.server.zap.core.service.UrlValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 class GuidedAuthSessionServiceTest {
 
@@ -37,187 +39,96 @@ class GuidedAuthSessionServiceTest {
     void setUp() {
         contextUserService = mock(ContextUserService.class);
         urlValidationService = mock(UrlValidationService.class);
-
-        AuthBootstrapProperties properties = new AuthBootstrapProperties();
-        properties.setAllowInlineSecrets(false);
-        properties.setAllowedCredentialReferences(List.of(
-                "file:" + tempDir.toAbsolutePath().normalize() + "/*",
-                "env:MCP_ZAP_AUTH_BOOTSTRAP_TEST_MISSING_ENV"
-        ));
-
-        CredentialReferenceResolver credentialReferenceResolver = new CredentialReferenceResolver(properties);
-        PreparedAuthSessionRegistry registry = new InMemoryPreparedAuthSessionRegistry();
-
-        service = new GuidedAuthSessionService(
-                List.of(
-                        new FormLoginAuthBootstrapProvider(contextUserService, credentialReferenceResolver, urlValidationService),
-                        new HeaderCredentialAuthBootstrapProvider(credentialReferenceResolver, urlValidationService)
-                ),
-                registry
+        service = serviceWith(
+                formProfile("shop-form", "https://shop.example.com", "file:" + formPasswordFile()),
+                headerProfile("orders-api-key", "https://api.example.com", "file:" + apiTokenFile())
         );
     }
 
     @Test
-    void prepareAndValidateFormSessionUsesExistingContextUserFlow() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-
-        when(contextUserService.upsertContext(
-                eq("shop-auth"),
-                eq(List.of(scopeRegex("https://shop.example.com"))),
-                eq(List.of(logoutRegex("https://shop.example.com"))),
-                eq(true)
-        )).thenReturn(Map.of("contextId", "1"));
-        when(contextUserService.configureContextAuthentication(
-                eq("1"),
-                eq("formBasedAuthentication"),
-                eq(authMethodConfig("https://shop.example.com/login", "username", "password")),
-                eq(".*Logout.*"),
-                eq(".*Sign in.*")
-        )).thenReturn(Map.of("contextId", "1"));
-        when(contextUserService.upsertUser(
-                eq("1"),
-                eq("zap-scan-user"),
-                startsWith("username=zap-scan-user&password="),
-                eq(true)
-        )).thenReturn(Map.of("userId", "7", "userName", "zap-scan-user"));
+    void prepareAndValidateFormSessionUsesOperatorProfile() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        stubFormUser("shop-form-auth", "1", "7");
         when(contextUserService.testUserAuthentication("1", "7"))
                 .thenReturn(Map.of("likelyAuthenticated", true));
 
-        String prepareResponse = service.prepareSession(
-                "https://shop.example.com",
-                "form",
-                "file:" + passwordFile,
-                null,
-                "shop-form-auth",
-                "shop-auth",
-                "https://shop.example.com/login",
-                "zap-scan-user",
-                "zap-scan-user",
-                "username",
-                "password",
-                null,
-                ".*Logout.*",
-                ".*Sign in.*"
-        );
+        String prepareResponse = service.prepareSession("shop-form", "https://shop.example.com");
 
-        assertThat(prepareResponse).contains("Guided auth session prepared.");
-        assertThat(prepareResponse).contains("Auth Kind: form");
-        assertThat(prepareResponse).contains("Context ID: 1");
-        assertThat(prepareResponse).contains("User ID: 7");
-        assertThat(prepareResponse).contains("Next Step: call zap_auth_session_validate");
-        assertThat(prepareResponse).doesNotContain("example-password-value");
+        assertThat(prepareResponse).contains(
+                "Guided auth session prepared.",
+                "Auth Profile: shop-form",
+                "Auth Kind: form",
+                "Authorized Origin: https://shop.example.com",
+                "Context ID: 1",
+                "User ID: 7",
+                "Next Step: call zap_auth_session_validate"
+        );
+        assertThat(prepareResponse).doesNotContain("example-password-value", "scan-password.txt");
         verify(urlValidationService).validateUrl("https://shop.example.com");
         verify(urlValidationService).validateUrl("https://shop.example.com/login");
 
-        String sessionId = extractSessionId(prepareResponse);
-        String validateResponse = service.validateSession(sessionId);
+        String validateResponse = service.validateSession(extractSessionId(prepareResponse));
 
-        assertThat(validateResponse).contains("Guided auth session validation complete.");
-        assertThat(validateResponse).contains("Valid: true");
-        assertThat(validateResponse).contains("Outcome: authenticated");
-        assertThat(validateResponse).doesNotContain("example-password-value");
+        assertThat(validateResponse).contains(
+                "Guided auth session validation complete.",
+                "Valid: true",
+                "Outcome: authenticated"
+        );
+        assertThat(validateResponse).doesNotContain("example-password-value", "scan-password.txt");
         verify(contextUserService).testUserAuthentication("1", "7");
     }
 
     @Test
-    void prepareHeaderSessionUsesCredentialReferenceWithoutPretendingEngineBindingExists() throws Exception {
-        Path tokenFile = tempDir.resolve("api-token.txt");
-        Files.writeString(tokenFile, "api-token-value", StandardCharsets.UTF_8);
+    void prepareHeaderSessionKeepsExistingGatewayOnlyBehavior() throws Exception {
+        Files.writeString(apiTokenFile(), "api-token-value", StandardCharsets.UTF_8);
 
-        String prepareResponse = service.prepareSession(
-                "https://api.example.com",
-                "api-key",
-                "file:" + tokenFile,
-                null,
-                "orders-api-key",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
+        String prepareResponse = service.prepareSession("orders-api-key", "https://api.example.com/orders");
+
+        assertThat(prepareResponse).contains(
+                "Auth Profile: orders-api-key",
+                "Auth Kind: api-key",
+                "Authorized Origin: https://api.example.com",
+                "Engine Binding: gateway contract only",
+                "Header Name: X-API-Key"
         );
+        assertThat(prepareResponse).doesNotContain("api-token-value", "api-token.txt");
+        verify(urlValidationService).validateUrl("https://api.example.com/orders");
 
-        assertThat(prepareResponse).contains("Guided auth session prepared.");
-        assertThat(prepareResponse).contains("Auth Kind: api-key");
-        assertThat(prepareResponse).contains("Engine Binding: gateway contract only");
-        assertThat(prepareResponse).contains("Header Name: X-API-Key");
-        verify(urlValidationService).validateUrl("https://api.example.com");
-
-        String sessionId = extractSessionId(prepareResponse);
-        String validateResponse = service.validateSession(sessionId);
-
-        assertThat(validateResponse).contains("Valid: true");
-        assertThat(validateResponse).contains("Outcome: reference_valid");
-        assertThat(validateResponse).contains("Current guided ZAP flows do not automatically inject header-based auth yet.");
+        String validateResponse = service.validateSession(extractSessionId(prepareResponse));
+        assertThat(validateResponse).contains(
+                "Valid: true",
+                "Outcome: reference_valid",
+                "Current guided ZAP flows do not automatically inject header-based auth yet."
+        );
     }
 
     @Test
-    void credentialReferencesMustBeOperatorAllowlisted() {
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://api.example.com",
-                "api-key",
-                "env:HOME",
-                null,
-                "orders-api-key",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("credentialReference is not in the operator allowlist");
-        assertRunbookDocuments("credentialReference is not in the operator allowlist");
-    }
+    void formCredentialCannotBeReboundToCallerSelectedOrigin() throws Exception {
+        assertThatThrownBy(() -> service.prepareSession("shop-form", "https://attacker.example"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("targetUrl origin is not authorized for auth profile");
 
-    @Test
-    void formLoginRejectsCrossOriginLoginUrlBeforeConfiguringZap() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://shop.example.com",
-                "form",
-                "file:" + passwordFile,
-                null,
-                "shop-form-auth",
-                "shop-auth",
-                "https://evil.example.test/login",
-                "zap-scan-user",
-                "zap-scan-user",
-                "username",
-                "password",
-                null,
-                ".*Logout.*",
-                ".*Sign in.*"
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("loginUrl must share the same origin as targetUrl");
-
-        verify(urlValidationService).validateUrl("https://shop.example.com");
-        verify(urlValidationService).validateUrl("https://evil.example.test/login");
+        verify(urlValidationService).validateUrl("https://attacker.example");
+        verify(urlValidationService).validateUrl("https://shop.example.com/login");
         verifyNoInteractions(contextUserService);
     }
 
     @Test
-    void formLoginEncodesAuthMethodConfigParamsToBlockParameterInjection() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-        String loginUrl = "https://shop.example.com/login?x=1&loginUrl=https://attacker.example/steal";
+    void profileAllowsCallerSelectedPathOnAuthorizedOrigin() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        stubFormUser("shop-form-auth", "3", "8");
 
-        when(contextUserService.upsertContext(
-                eq("shop-auth"),
-                eq(List.of(scopeRegex("https://shop.example.com"))),
-                eq(List.of(logoutRegex("https://shop.example.com"))),
-                eq(true)
-        )).thenReturn(Map.of("contextId", "1"));
+        String response = service.prepareSession("shop-form", "https://shop.example.com/admin");
+
+        assertThat(response).contains("Target URL: https://shop.example.com/admin");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sameProfileContextScopeIsImmutableAcrossCallerPaths() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        when(contextUserService.upsertContext(eq("shop-form-auth"), anyList(), anyList(), eq(true)))
+                .thenReturn(Map.of("contextId", "1"));
         when(contextUserService.upsertUser(
                 eq("1"),
                 eq("zap-scan-user"),
@@ -225,22 +136,69 @@ class GuidedAuthSessionServiceTest {
                 eq(true)
         )).thenReturn(Map.of("userId", "7", "userName", "zap-scan-user"));
 
-        service.prepareSession(
-                "https://shop.example.com",
-                "form",
-                "file:" + passwordFile,
-                null,
-                "shop-form-auth",
-                "shop-auth",
-                loginUrl,
-                "zap-scan-user",
-                "zap-scan-user",
-                "user.name",
-                "pass-word",
-                null,
-                ".*Logout.*",
-                ".*Sign in.*"
+        service.prepareSession("shop-form", "https://shop.example.com/admin");
+        service.prepareSession("shop-form", "https://shop.example.com/orders");
+
+        ArgumentCaptor<List<String>> scopes = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<String>> exclusions = ArgumentCaptor.forClass(List.class);
+        verify(contextUserService, times(2)).upsertContext(
+                eq("shop-form-auth"),
+                scopes.capture(),
+                exclusions.capture(),
+                eq(true)
         );
+        List<String> firstScope = scopes.getAllValues().get(0);
+        List<String> secondScope = scopes.getAllValues().get(1);
+        assertThat(firstScope).isEqualTo(secondScope).hasSize(1);
+        assertThat(exclusions.getAllValues().get(0))
+                .isEqualTo(exclusions.getAllValues().get(1))
+                .hasSize(1);
+
+        String profileScope = firstScope.get(0);
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com")).isTrue();
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com/admin")).isTrue();
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com/admin/users")).isTrue();
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com/orders")).isTrue();
+        assertThat(Pattern.matches(profileScope, "HTTPS://SHOP.EXAMPLE.COM:443/orders")).isTrue();
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com./orders")).isFalse();
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com.attacker.test/admin")).isFalse();
+        assertThat(Pattern.matches(profileScope, "https://shop.example.com:8443/admin")).isFalse();
+        assertThat(Pattern.matches(profileScope, "http://shop.example.com/admin")).isFalse();
+    }
+
+    @Test
+    void eachProfileOwnsADistinctGuidedZapContext() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        service = serviceWith(
+                formProfile("shop-a", "https://shop.example.com", "file:" + formPasswordFile()),
+                formProfile("shop-b", "https://shop.example.com", "file:" + formPasswordFile())
+        );
+        stubFormUser("shop-a-auth", "11", "21");
+        stubFormUser("shop-b-auth", "12", "22");
+
+        String first = service.prepareSession("shop-a", "https://shop.example.com");
+        String second = service.prepareSession("shop-b", "https://shop.example.com");
+
+        assertThat(first).contains("Context Name: shop-a-auth");
+        assertThat(second).contains("Context Name: shop-b-auth");
+    }
+
+    @Test
+    void formLoginEncodesProfileConfigurationToBlockParameterInjection() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        String loginUrl = "https://shop.example.com/login?x=1&loginUrl=https://attacker.example/steal";
+        AuthBootstrapProperties.Profile profile = formProfile(
+                "shop-form",
+                "https://shop.example.com",
+                "file:" + formPasswordFile()
+        );
+        profile.setLoginUrl(loginUrl);
+        profile.setUsernameField("user.name");
+        profile.setPasswordField("pass-word");
+        service = serviceWith(profile);
+        stubFormUser("shop-form-auth", "1", "7");
+
+        service.prepareSession("shop-form", "https://shop.example.com");
 
         verify(contextUserService).configureContextAuthentication(
                 eq("1"),
@@ -252,277 +210,143 @@ class GuidedAuthSessionServiceTest {
     }
 
     @Test
-    void formLoginRejectsUnsafeFieldNamesBeforeConfiguringZap() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-
-        assertThatThrownBy(() -> service.prepareSession(
+    void formLoginRejectsUnsafeProfileFieldBeforeReadingSecretOrConfiguringZap() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        AuthBootstrapProperties.Profile profile = formProfile(
+                "shop-form",
                 "https://shop.example.com",
-                "form",
-                "file:" + passwordFile,
-                null,
-                "shop-form-auth",
-                "shop-auth",
-                "https://shop.example.com/login",
-                "zap-scan-user",
-                "zap-scan-user",
-                "username&loginUrl=https://attacker.example/steal",
-                "password",
-                null,
-                ".*Logout.*",
-                ".*Sign in.*"
-        )).isInstanceOf(IllegalArgumentException.class)
+                "file:" + formPasswordFile()
+        );
+        profile.setUsernameField("username&loginUrl=https://attacker.example/steal");
+        service = serviceWith(profile);
+
+        assertThatThrownBy(() -> service.prepareSession("shop-form", "https://shop.example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("usernameField contains unsupported characters");
 
-        verify(urlValidationService).validateUrl("https://shop.example.com");
-        verify(urlValidationService).validateUrl("https://shop.example.com/login");
         verifyNoInteractions(contextUserService);
     }
 
     @Test
-    void formLoginRejectsUnsafePasswordFieldBeforeConfiguringZap() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-
-        assertThatThrownBy(() -> service.prepareSession(
+    void missingProfileCredentialFailsBeforeZapMutation() {
+        String envName = "MCP_ZAP_AUTH_PROFILE_TEST_MISSING";
+        AuthBootstrapProperties.Profile profile = formProfile(
+                "missing-env",
                 "https://shop.example.com",
-                "form",
-                "file:" + passwordFile,
-                null,
-                "shop-form-auth",
-                "shop-auth",
-                "https://shop.example.com/login",
-                "zap-scan-user",
-                "zap-scan-user",
-                "username",
-                "password&loginUrl=https://attacker.example/steal",
-                null,
-                ".*Logout.*",
-                ".*Sign in.*"
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("passwordField contains unsupported characters");
-
-        verify(urlValidationService).validateUrl("https://shop.example.com");
-        verify(urlValidationService).validateUrl("https://shop.example.com/login");
-        verifyNoInteractions(contextUserService);
-    }
-
-    @Test
-    void formLoginEscapesContextScopeRegexLiterals() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-        String targetUrl = "https://shop.example.com/app.v1/(beta)";
-        String expectedIncludeRegex = scopeRegex(targetUrl);
-
-        when(contextUserService.upsertContext(
-                eq("shop-auth"),
-                eq(List.of(expectedIncludeRegex)),
-                eq(List.of(logoutRegex(targetUrl))),
-                eq(true)
-        )).thenReturn(Map.of("contextId", "1"));
-        when(contextUserService.upsertUser(
-                eq("1"),
-                eq("zap-scan-user"),
-                startsWith("username=zap-scan-user&password="),
-                eq(true)
-        )).thenReturn(Map.of("userId", "7", "userName", "zap-scan-user"));
-
-        service.prepareSession(
-                targetUrl,
-                "form",
-                "file:" + passwordFile,
-                null,
-                "shop-form-auth",
-                "shop-auth",
-                "https://shop.example.com/app.v1/(beta)/login",
-                "zap-scan-user",
-                "zap-scan-user",
-                "username",
-                "password",
-                null,
-                ".*Logout.*",
-                ".*Sign in.*"
+                "env:" + envName
         );
+        service = serviceWith(profile);
 
-        Pattern scopePattern = Pattern.compile(expectedIncludeRegex);
-        assertThat(scopePattern.matcher("https://shop.example.com/app.v1/(beta)/checkout").matches()).isTrue();
-        assertThat(scopePattern.matcher("https://shopXexampleYcom/app.v1/(beta)/checkout").matches()).isFalse();
-        assertThat(scopePattern.matcher("https://shop.example.com/appXv1/(beta)/checkout").matches()).isFalse();
-    }
-
-    @Test
-    void inlineSecretsAreRejectedByDefault() {
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://api.example.com",
-                "bearer",
-                null,
-                "inline-value-for-local-test",
-                "local-bearer",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("inlineSecret is disabled by default");
-        assertRunbookDocuments("inlineSecret is disabled by default");
-    }
-
-    @Test
-    void missingCredentialReferenceHasDocumentedFailure() {
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://api.example.com",
-                "bearer",
-                null,
-                null,
-                "orders-bearer",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Provide credentialReference or inlineSecret");
-        assertRunbookDocuments("Provide credentialReference or inlineSecret");
-    }
-
-    @Test
-    void missingEnvironmentCredentialReferenceHasDocumentedFailure() {
-        String envName = "MCP_ZAP_AUTH_BOOTSTRAP_TEST_MISSING_ENV";
-
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://api.example.com",
-                "api-key",
-                "env:" + envName,
-                null,
-                "orders-api-key",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Environment variable '" + envName + "' is missing or blank");
-        assertRunbookDocuments("Environment variable ... is missing or blank");
-    }
-
-    @Test
-    void unreadableFileCredentialReferenceHasDocumentedFailure() {
-        Path missingFile = tempDir.resolve("missing-secret.txt");
-
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://api.example.com",
-                "api-key",
-                "file:" + missingFile,
-                null,
-                "orders-api-key",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unable to read credentialReference file");
-        assertRunbookDocuments("Unable to read credentialReference file");
-    }
-
-    @Test
-    void badAuthKindHasDocumentedFailure() {
-        assertThatThrownBy(() -> service.prepareSession(
-                "https://api.example.com",
-                "session-cookie",
-                "env:MCP_ZAP_AUTH_BOOTSTRAP_TEST_MISSING_ENV",
-                null,
-                "unsupported-auth",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("authKind must be one of: form, bearer, api-key");
-        assertRunbookDocuments("authKind must be one of: form, bearer, api-key");
-    }
-
-    @Test
-    void unknownSessionHasDocumentedFailure() {
-        assertThatThrownBy(() -> service.validateSession("missing-session"))
+        assertThatThrownBy(() -> service.prepareSession("missing-env", "https://shop.example.com"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Unknown auth session ID: missing-session");
-        assertRunbookDocuments("Unknown auth session ID");
+                .hasMessage("Auth profile credential could not be resolved")
+                .hasNoCause();
+
+        verifyNoInteractions(contextUserService);
+        assertRunbookDocuments("Auth profile credential could not be resolved");
+    }
+
+    @Test
+    void unreadableProfileFileFailsBeforeZapMutation() {
+        AuthBootstrapProperties.Profile profile = formProfile(
+                "missing-file",
+                "https://shop.example.com",
+                "file:" + tempDir.resolve("missing-secret")
+        );
+        service = serviceWith(profile);
+
+        assertThatThrownBy(() -> service.prepareSession("missing-file", "https://shop.example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Auth profile credential could not be resolved")
+                .hasNoCause();
+
+        verifyNoInteractions(contextUserService);
+        assertRunbookDocuments("Auth profile credential could not be resolved");
+    }
+
+    @Test
+    void unknownProfileHasDocumentedFailure() {
+        assertThatThrownBy(() -> service.prepareSession("missing", "https://shop.example.com"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unknown auth profile ID: missing");
+
+        verifyNoInteractions(contextUserService);
+        assertRunbookDocuments("Unknown auth profile ID");
     }
 
     @Test
     void failedFormValidationHasDocumentedOutcomeAndNoSecretLeakage() throws Exception {
-        Path passwordFile = tempDir.resolve("scan-password.txt");
-        Files.writeString(passwordFile, "example-password-value", StandardCharsets.UTF_8);
-
-        when(contextUserService.upsertContext(
-                eq("shop-auth"),
-                eq(List.of(scopeRegex("https://shop.example.com"))),
-                eq(List.of(logoutRegex("https://shop.example.com"))),
-                eq(true)
-        )).thenReturn(Map.of("contextId", "1"));
-        when(contextUserService.configureContextAuthentication(
-                eq("1"),
-                eq("formBasedAuthentication"),
-                eq(authMethodConfig("https://shop.example.com/login", "username", "password")),
-                eq(".*Logout.*"),
-                eq(".*Sign in.*")
-        )).thenReturn(Map.of("contextId", "1"));
-        when(contextUserService.upsertUser(
-                eq("1"),
-                eq("zap-scan-user"),
-                startsWith("username=zap-scan-user&password="),
-                eq(true)
-        )).thenReturn(Map.of("userId", "7", "userName", "zap-scan-user"));
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        stubFormUser("shop-form-auth", "1", "7");
         when(contextUserService.testUserAuthentication("1", "7"))
                 .thenReturn(Map.of("likelyAuthenticated", false));
 
-        String prepareResponse = service.prepareSession(
-                "https://shop.example.com",
-                "form",
-                "file:" + passwordFile,
-                null,
+        String prepared = service.prepareSession("shop-form", "https://shop.example.com");
+        String response = service.validateSession(extractSessionId(prepared));
+
+        assertThat(response).contains("Valid: false", "Outcome: authentication_failed");
+        assertThat(response).doesNotContain("example-password-value", "scan-password.txt");
+        assertRunbookDocuments("authentication_failed");
+    }
+
+    @Test
+    void indeterminateFormValidationFailsClosed() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        stubFormUser("shop-form-auth", "1", "7");
+        when(contextUserService.testUserAuthentication("1", "7"))
+                .thenReturn(Map.of());
+
+        String prepared = service.prepareSession("shop-form", "https://shop.example.com");
+        String response = service.validateSession(extractSessionId(prepared));
+
+        assertThat(response).contains(
+                "Valid: false",
+                "Outcome: authentication_failed",
+                "likelyAuthenticated=null"
+        );
+        assertThat(response).doesNotContain("example-password-value", "scan-password.txt");
+    }
+
+    @Test
+    void validationRejectsSessionWhoseStoredLoginEscapesProfileOrigin() throws Exception {
+        Files.writeString(formPasswordFile(), "example-password-value", StandardCharsets.UTF_8);
+        PreparedAuthSessionRegistry registry = new InMemoryPreparedAuthSessionRegistry();
+        PreparedAuthSession session = registry.save(new PreparedAuthSession(
+                "tampered",
+                "shop-form",
+                AuthBootstrapKind.FORM,
+                "zap-form-login",
+                new mcp.server.zap.core.gateway.TargetDescriptor(
+                        mcp.server.zap.core.gateway.TargetDescriptor.Kind.WEB,
+                        "https://shop.example.com",
+                        "shop-form-auth"
+                ),
+                HttpOrigin.fromConfiguredOrigin("https://shop.example.com"),
+                "file:" + formPasswordFile(),
                 "shop-form-auth",
-                "shop-auth",
-                "https://shop.example.com/login",
+                "1",
                 "zap-scan-user",
-                "zap-scan-user",
-                "username",
-                "password",
+                "7",
                 null,
-                ".*Logout.*",
-                ".*Sign in.*"
+                "https://attacker.example/login",
+                true
+        ));
+        CredentialReferenceResolver credentialResolver = new CredentialReferenceResolver();
+        service = new GuidedAuthSessionService(
+                List.of(new FormLoginAuthBootstrapProvider(contextUserService, credentialResolver, urlValidationService)),
+                registry,
+                new AuthProfileResolver(propertiesWith(formProfile(
+                        "shop-form",
+                        "https://shop.example.com",
+                        "file:" + formPasswordFile()
+                )))
         );
 
-        String validateResponse = service.validateSession(extractSessionId(prepareResponse));
+        assertThatThrownBy(() -> service.validateSession(session.sessionId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("auth session loginUrl origin is not authorized for auth profile");
 
-        assertThat(validateResponse).contains("Valid: false");
-        assertThat(validateResponse).contains("Outcome: authentication_failed");
-        assertThat(validateResponse).contains("likelyAuthenticated=false");
-        assertThat(validateResponse).doesNotContain("example-password-value");
-        assertRunbookDocuments("authentication_failed");
+        verifyNoInteractions(contextUserService);
     }
 
     @Test
@@ -530,16 +354,104 @@ class GuidedAuthSessionServiceTest {
         String runbook = authRunbook();
 
         assertThat(runbook).contains(
-                "authKind must be one of: form, bearer, api-key",
-                "Provide credentialReference or inlineSecret",
-                "Environment variable ... is missing or blank",
-                "Unable to read credentialReference file",
-                "reference_missing",
+                "Unknown auth profile ID",
+                "targetUrl origin is not authorized for auth profile",
+                "Auth profile credential could not be resolved",
                 "authentication_failed",
                 "Unknown auth session ID",
-                "form-login prepare and validate"
+                "form-login prepare and validate",
+                "`zap_crawl_start`",
+                "`zap_attack_start`"
         );
-        assertThat(runbook).doesNotContain("top-secret-token", "StrongPassword123!");
+        assertThat(runbook).doesNotContain(
+                "top-secret-token",
+                "StrongPassword123!",
+                "`zap_crawl`",
+                "`zap_attack`"
+        );
+    }
+
+    @Test
+    void migrationVerifierRequiresAffirmativeAuthenticationEvidence() throws Exception {
+        String guide = Files.readString(Path.of(
+                "docs/src/content/docs/scanning/authenticated-scanning-best-practices.md"));
+
+        assertThat(guide).contains(
+                "grep -F 'Valid: true'",
+                "grep -F 'Outcome: authenticated'",
+                "grep -F 'likelyAuthenticated=true'",
+                "set -euo pipefail",
+                "MCP_ZAP_IMAGE_TAG=sha-REPLACE_WITH_FULL_MAIN_COMMIT_SHA",
+                "[[ \"$MCP_ZAP_IMAGE_TAG\" =~ ^sha-[0-9a-f]{40}$ ]]",
+                "--set-string \"mcp.image.tag=$MCP_ZAP_IMAGE_TAG\"",
+                "--show-only templates/mcp-deployment.yaml",
+                "grep -E \"^[[:space:]]+image: \\\"[^\\\"]+:${MCP_ZAP_IMAGE_TAG}\\\"$\""
+        ).doesNotContain("grep -Eq '^[[:space:]]+tag:");
+    }
+
+    private GuidedAuthSessionService serviceWith(AuthBootstrapProperties.Profile... profiles) {
+        CredentialReferenceResolver credentialResolver = new CredentialReferenceResolver();
+        return new GuidedAuthSessionService(
+                List.of(
+                        new FormLoginAuthBootstrapProvider(contextUserService, credentialResolver, urlValidationService),
+                        new HeaderCredentialAuthBootstrapProvider(credentialResolver, urlValidationService)
+                ),
+                new InMemoryPreparedAuthSessionRegistry(),
+                new AuthProfileResolver(propertiesWith(profiles))
+        );
+    }
+
+    private AuthBootstrapProperties propertiesWith(AuthBootstrapProperties.Profile... profiles) {
+        AuthBootstrapProperties properties = new AuthBootstrapProperties();
+        properties.setProfiles(List.of(profiles));
+        return properties;
+    }
+
+    private AuthBootstrapProperties.Profile formProfile(String id, String allowedOrigin, String credentialReference) {
+        AuthBootstrapProperties.Profile profile = new AuthBootstrapProperties.Profile();
+        profile.setId(id);
+        profile.setKind("form");
+        profile.setAllowedOrigin(allowedOrigin);
+        profile.setCredentialReference(credentialReference);
+        profile.setLoginUrl(allowedOrigin + "/login");
+        profile.setUsername("zap-scan-user");
+        profile.setZapUserName("zap-scan-user");
+        profile.setUsernameField("username");
+        profile.setPasswordField("password");
+        profile.setLoggedInIndicatorRegex(".*Logout.*");
+        profile.setLoggedOutIndicatorRegex(".*Sign in.*");
+        return profile;
+    }
+
+    private AuthBootstrapProperties.Profile headerProfile(String id, String allowedOrigin, String credentialReference) {
+        AuthBootstrapProperties.Profile profile = new AuthBootstrapProperties.Profile();
+        profile.setId(id);
+        profile.setKind("api-key");
+        profile.setAllowedOrigin(allowedOrigin);
+        profile.setCredentialReference(credentialReference);
+        return profile;
+    }
+
+    private void stubFormUser(String contextName, String contextId, String userId) {
+        when(contextUserService.upsertContext(
+                eq(contextName),
+                anyList(),
+                anyList(),
+                eq(true)
+        )).thenReturn(Map.of("contextId", contextId));
+        when(contextUserService.configureContextAuthentication(
+                eq(contextId),
+                eq("formBasedAuthentication"),
+                eq(authMethodConfig("https://shop.example.com/login", "username", "password")),
+                eq(".*Logout.*"),
+                eq(".*Sign in.*")
+        )).thenReturn(Map.of("contextId", contextId));
+        when(contextUserService.upsertUser(
+                eq(contextId),
+                eq("zap-scan-user"),
+                startsWith("username=zap-scan-user&password="),
+                eq(true)
+        )).thenReturn(Map.of("userId", userId, "userName", "zap-scan-user"));
     }
 
     private String extractSessionId(String response) {
@@ -551,35 +463,25 @@ class GuidedAuthSessionServiceTest {
         throw new AssertionError("No session ID found in response: " + response);
     }
 
-    private void assertRunbookDocuments(String expectedText) {
-        assertThat(authRunbook()).contains(expectedText);
-    }
-
     private String authMethodConfig(String loginUrl, String usernameField, String passwordField) {
         String loginRequestData = usernameField + "={%username%}&" + passwordField + "={%password%}";
         return "loginUrl=" + urlEncode(loginUrl) + "&loginRequestData=" + urlEncode(loginRequestData);
     }
 
-    private String scopeRegex(String targetUrl) {
-        URI uri = URI.create(targetUrl);
-        String path = normalizePathPrefix(uri.getPath());
-        return Pattern.quote(uri.getScheme() + "://" + uri.getAuthority() + path) + ".*";
-    }
-
-    private String logoutRegex(String targetUrl) {
-        URI uri = URI.create(targetUrl);
-        return Pattern.quote(uri.getScheme() + "://" + uri.getAuthority() + "/logout") + ".*";
-    }
-
-    private String normalizePathPrefix(String path) {
-        if (path == null || path.isBlank() || "/".equals(path)) {
-            return "/";
-        }
-        return path.endsWith("/") ? path : path + "/";
-    }
-
     private String urlEncode(String value) {
         return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private Path formPasswordFile() {
+        return tempDir.resolve("scan-password.txt");
+    }
+
+    private Path apiTokenFile() {
+        return tempDir.resolve("api-token.txt");
+    }
+
+    private void assertRunbookDocuments(String expectedText) {
+        assertThat(authRunbook()).contains(expectedText);
     }
 
     private String authRunbook() {

--- a/src/test/java/mcp/server/zap/core/service/auth/bootstrap/HttpOriginTest.java
+++ b/src/test/java/mcp/server/zap/core/service/auth/bootstrap/HttpOriginTest.java
@@ -1,0 +1,52 @@
+package mcp.server.zap.core.service.auth.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class HttpOriginTest {
+
+    @Test
+    void canonicalizesCaseAndDefaultPort() {
+        HttpOrigin origin = HttpOrigin.fromConfiguredOrigin("https://SHOP.Example.com:443");
+
+        assertThat(origin).isEqualTo(HttpOrigin.fromUrl("https://shop.example.com/account"));
+        assertThat(origin.toString()).isEqualTo("https://shop.example.com");
+    }
+
+    @Test
+    void rejectsTerminalDotInsteadOfAuthorizingADifferentHostname() {
+        assertThatThrownBy(() -> HttpOrigin.fromConfiguredOrigin("https://shop.example.com."))
+                .hasMessage("allowedOrigin host must not end with a dot");
+        assertThatThrownBy(() -> HttpOrigin.fromUrl("https://shop.example.com./account"))
+                .hasMessage("URL host must not end with a dot");
+    }
+
+    @Test
+    void distinguishesSchemePortAndSiblingHost() {
+        HttpOrigin origin = HttpOrigin.fromConfiguredOrigin("https://shop.example.com");
+
+        assertThat(origin.matches("http://shop.example.com")).isFalse();
+        assertThat(origin.matches("https://shop.example.com:8443")).isFalse();
+        assertThat(origin.matches("https://shop.example.com.attacker.test")).isFalse();
+    }
+
+    @Test
+    void configuredOriginRejectsPathQueryFragmentAndUserInfo() {
+        assertThatThrownBy(() -> HttpOrigin.fromConfiguredOrigin("https://shop.example.com/login"))
+                .hasMessage("allowedOrigin must contain only scheme, host, and optional port");
+        assertThatThrownBy(() -> HttpOrigin.fromConfiguredOrigin("https://shop.example.com?x=1"))
+                .hasMessage("allowedOrigin must contain only scheme, host, and optional port");
+        assertThatThrownBy(() -> HttpOrigin.fromConfiguredOrigin("https://shop.example.com#fragment"))
+                .hasMessage("allowedOrigin must contain only scheme, host, and optional port");
+        assertThatThrownBy(() -> HttpOrigin.fromConfiguredOrigin("https://user@shop.example.com"))
+                .hasMessage("allowedOrigin must not contain user information");
+    }
+
+    @Test
+    void rejectsExplicitlyEmptyPort() {
+        assertThatThrownBy(() -> HttpOrigin.fromUrl("https://shop.example.com:/account"))
+                .hasMessage("URL port cannot be empty");
+    }
+}

--- a/src/test/java/mcp/server/zap/core/service/policy/ToolExecutionPolicyAspectTest.java
+++ b/src/test/java/mcp/server/zap/core/service/policy/ToolExecutionPolicyAspectTest.java
@@ -26,6 +26,28 @@ import static org.mockito.Mockito.when;
 class ToolExecutionPolicyAspectTest {
 
     @Test
+    void authProfileIdDoesNotHideTargetFromRuntimePolicy() throws Throwable {
+        ToolExecutionPolicyService policyService = mock(ToolExecutionPolicyService.class);
+        ToolExecutionPolicyAspect aspect = new ToolExecutionPolicyAspect(policyService);
+
+        Object response = aspect.enforcePolicy(
+                joinPointFor(
+                        "prepareAuthSession",
+                        new String[]{"profileId", "targetUrl"},
+                        new Object[]{"shop-staging", "https://shop.example.com/admin"}
+                ),
+                toolAnnotation("prepareAuthSession", String.class, String.class)
+        );
+
+        assertThat(response).isEqualTo("tool-result");
+        verify(policyService).enforce(
+                "zap_auth_session_prepare",
+                "https://shop.example.com/admin",
+                null
+        );
+    }
+
+    @Test
     void hostlessReportReadArgumentsCanBeAllowedByRuntimePolicy() throws Throwable {
         PolicyEnforcementProperties properties = new PolicyEnforcementProperties();
         properties.setMode(PolicyEnforcementProperties.Mode.ENFORCE);
@@ -199,6 +221,11 @@ class ToolExecutionPolicyAspectTest {
         @Tool(name = "zap_passive_scan_status")
         String passiveStatus() {
             return "unused";
+        }
+
+        @Tool(name = "zap_auth_session_prepare")
+        String prepareAuthSession(String profileId, String targetUrl) {
+            return profileId + ":" + targetUrl;
         }
     }
 }

--- a/src/test/java/mcp/server/zap/operator/ProductionSimulationRunbookTest.java
+++ b/src/test/java/mcp/server/zap/operator/ProductionSimulationRunbookTest.java
@@ -48,6 +48,7 @@ class ProductionSimulationRunbookTest {
                 "Release evidence",
                 "Customer handoff",
                 "Secret handling",
+                "Session ID SHA-256 fingerprint (never raw)",
                 "guided operation ID and backend scan/job ID"
         );
         assertThat(runbook).doesNotContain("top-secret-token", "StrongPassword123!");


### PR DESCRIPTION
This pull request introduces significant changes to authentication profile management, security policy, and operator workflows, focusing on improving security, clarity, and operational guidance for authentication bootstrap and validation. The main themes are: migration to operator-managed authentication profiles, stricter credential and origin binding, enhanced container security, and improved operator documentation and evidence handling.

**Authentication and Security Improvements:**

* Changed `zap_auth_session_prepare` to require only `profileId` and `targetUrl`, deprecating direct credential reference inputs in favor of operator-managed profiles (`mcp.server.auth.bootstrap.profiles`).
* Each guided-auth credential and login configuration is now bound to a single, operator-approved canonical origin. The system rechecks origin before validation or authenticated actions, and removes caller-selected credentials and login settings.
* Made ZAP context scope immutable and origin-wide per guided profile; login indicators are validated before any secret resolution or engine mutation, and credential-source metadata is kept out of MCP caller errors.
* Form-login validation now fails closed unless ZAP reports `likelyAuthenticated=true`, and terminal-dot target hosts are rejected before further checks.

**Container and Deployment Hardening:**

* The JVM container now runs as UID/GID 1000, and the authenticated-profile Helm migration verifies and deploys the exact main-commit image tag. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R23) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R30)
* Dockerfile changes ensure the application runs as a non-root user and all relevant files are owned by UID/GID 1000.

**Operator Documentation and Workflow Updates:**

* Operator runbooks and simulation guides have been overhauled to reflect the new profile-based workflow: all authentication now uses operator-managed profiles with explicit allowed origins, credential references, and login settings. Raw session IDs should never be recorded outside live workflows; only their SHA-256 fingerprints are retained for evidence. [[1]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL15-R21) [[2]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL37-R38) [[3]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL48-L61) [[4]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eR68-R81) [[5]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL92-R141) [[6]](diffhunk://#diff-ff287f157861e972d402f4095ea2a24bc765c8a10332e72b4ee14f592c180ca5L83-R93) [[7]](diffhunk://#diff-ff287f157861e972d402f4095ea2a24bc765c8a10332e72b4ee14f592c180ca5L121-R122) [[8]](diffhunk://#diff-3d25f1d23390130f6a5514833f0e3fa9b0eafe67511e1cf4d6dcde88b135e504L56-R61) [[9]](diffhunk://#diff-3d25f1d23390130f6a5514833f0e3fa9b0eafe67511e1cf4d6dcde88b135e504L90-R90)
* Error classification and troubleshooting steps now focus on profile validity, origin authorization, and credential resolution, rather than direct input errors.
* Operator evidence and escalation rules have been updated to avoid exposing sensitive credential references or raw secrets in logs, tickets, or support notes. [[1]](diffhunk://#diff-ff287f157861e972d402f4095ea2a24bc765c8a10332e72b4ee14f592c180ca5L121-R122) [[2]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL205-R211) [[3]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL224-R224)

**Migration and Compatibility:**

* Added migration recipes for executable-JAR, Compose, and Helm, including secret injection, required restart behavior, and live prepare/validate verification to support the new authentication workflow.

**Test and Build Pipeline:**

* Updated to Boot-managed Testcontainers `2.0.5`, Spring Boot `4.1.0`, and aligned dependencies for improved build and test reliability.

These changes collectively enforce stricter authentication boundaries, improve operational safety, and provide clearer guidance for operators managing authentication in production and staging environments.