### PR TITLE
Add form-login authentication guide and clean up documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,16 @@ The default Compose stack publishes host ports on `127.0.0.1` only. Set `MCP_ZAP
 Client setup:
 
 - [Self-Serve First Run](https://danieltse.org/mcp-zap-server/getting-started/self-serve-first-run/)
-- [Authentication Quick Start](https://danieltse.org/mcp-zap-server/getting-started/authentication-quick-start/)
+- [MCP Access Authentication](https://danieltse.org/mcp-zap-server/getting-started/authentication-quick-start/)
 - [MCP Client Configuration](https://danieltse.org/mcp-zap-server/getting-started/mcp-client-authentication/)
+- [Optional Target Form-Login](https://danieltse.org/mcp-zap-server/getting-started/form-login-target-authentication/)
 - [Tool Surfaces](https://danieltse.org/mcp-zap-server/getting-started/tool-surfaces/)
 - [Agent install notes](./llms-install.md)
+
+There are two independent authentication layers. The API key or JWT lets
+Cursor call MCP ZAP Server. An optional target-auth profile lets ZAP log in to
+an application you are authorized to scan. Most first runs need only the MCP
+API key; never put a target website password in Cursor or an MCP prompt.
 
 ## Discovery Metadata
 
@@ -119,7 +125,7 @@ The default posture is intentionally conservative:
 - `none` mode is for explicit local dev/test only.
 - Docker Compose binds published ports to loopback by default.
 - URL validation blocks localhost, private networks, and link-local targets by default.
-- Guided auth uses operator-managed profiles that bind exact server-side credential references and login settings to one approved origin; callers provide only `profileId` and `targetUrl`.
+- Target authentication is optional and profiles default to an empty list. When enabled, guided auth binds an exact server-side credential reference and login settings to one approved origin; callers provide only `profileId` and `targetUrl`.
 - Public auth exchange endpoints are rate-limited.
 - MCP request bodies have a hard early size cap.
 
@@ -127,7 +133,8 @@ Production and shared deployments should review:
 
 - [Security Modes](https://danieltse.org/mcp-zap-server/security-modes/)
 - [JWT Authentication](https://danieltse.org/mcp-zap-server/security-modes/jwt-authentication/)
-- [Authenticated Scanning Best Practices](https://danieltse.org/mcp-zap-server/scanning/authenticated-scanning-best-practices/)
+- [Optional Target Form-Login](https://danieltse.org/mcp-zap-server/getting-started/form-login-target-authentication/)
+- [Authenticated Scanning Reference](https://danieltse.org/mcp-zap-server/scanning/authenticated-scanning-best-practices/)
 - [Abuse Protection](https://danieltse.org/mcp-zap-server/operations/abuse-protection/)
 - [Production Readiness Checklist](https://danieltse.org/mcp-zap-server/operations/production-checklist/)
 - [Security Policy](./SECURITY.md)
@@ -176,8 +183,9 @@ Start here:
 - [Full documentation](https://danieltse.org/mcp-zap-server/)
 - [Self-Serve First Run](https://danieltse.org/mcp-zap-server/getting-started/self-serve-first-run/)
 - [OSS Extension Model](./docs/extensions/README.md)
-- [Authentication Quick Start](https://danieltse.org/mcp-zap-server/getting-started/authentication-quick-start/)
+- [MCP Access Authentication](https://danieltse.org/mcp-zap-server/getting-started/authentication-quick-start/)
 - [MCP Client Authentication](https://danieltse.org/mcp-zap-server/getting-started/mcp-client-authentication/)
+- [Optional Target Form-Login](https://danieltse.org/mcp-zap-server/getting-started/form-login-target-authentication/)
 - [Tool Surfaces](https://danieltse.org/mcp-zap-server/getting-started/tool-surfaces/)
 
 Scanning:

--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,6 @@ repositories {
 
 ext {
     set('springAiVersion', "2.0.0")
-    set('jackson-2-bom.version', "2.22.0")
-    set('logback.version', "1.5.36")
-    set('netty.version', "4.2.15.Final")
-    set('postgresql.version', "42.7.11")
     set('commonsCompressVersion', "1.28.0")
 }
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -36,8 +36,9 @@ export default defineConfig({
 						{ label: 'root@localhost:~', link: '/' },
 						{ slug: 'getting-started/self-serve-first-run' },
 						{ slug: 'getting-started/authentication-quick-start' },
-						{ slug: 'getting-started/tool-surfaces' },
 						{ slug: 'getting-started/mcp-client-authentication' },
+						{ slug: 'getting-started/form-login-target-authentication' },
+						{ slug: 'getting-started/tool-surfaces' },
 						{ slug: 'getting-started/jwt-quick-start' },
 						{ slug: 'getting-started/tool-scope-authorization' },
 					],
@@ -45,8 +46,8 @@ export default defineConfig({
 				{
 					label: 'Scanning',
 					items: [
-						{ slug: 'scanning/scan-execution-modes' },
 						{ slug: 'scanning/mcp-client-scan-to-evidence' },
+						{ slug: 'scanning/scan-execution-modes' },
 						{ slug: 'scanning/ajax-spider' },
 						{ slug: 'scanning/passive-scan' },
 						{ slug: 'scanning/seeded-api-gate-playbook' },

--- a/docs/getting-started/SELF_SERVE_FIRST_RUN.md
+++ b/docs/getting-started/SELF_SERVE_FIRST_RUN.md
@@ -72,7 +72,18 @@ tool call.
 - The default Compose stack wires Open WebUI to the local MCP server with the
   generated API key.
 
-## 5. Use The Guided Happy Path
+## 5. Decide Whether The Target Needs Login
+
+Most first runs should skip target authentication. The bundled Juice Shop and
+Petstore examples can be scanned without an auth profile.
+
+If your authorized target requires a traditional username/password HTML form,
+use the
+[Form-Login Target Authentication guide](https://danieltse.org/mcp-zap-server/getting-started/form-login-target-authentication/).
+That optional setup is separate from the API key or JWT used by Cursor. Never
+put the website password in Cursor or an MCP prompt.
+
+## 6. Use The Guided Happy Path
 
 For the full target-to-evidence workflow, use the
 [MCP Client Scan-To-Evidence Guide](https://danieltse.org/mcp-zap-server/scanning/mcp-client-scan-to-evidence/).
@@ -88,7 +99,7 @@ Use prompts like these:
 That is enough to prove the end-to-end self-serve path without dragging a new
 user through every advanced feature in the repo.
 
-## 6. If It Breaks
+## 7. If It Breaks
 
 Use this order:
 

--- a/docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md
+++ b/docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md
@@ -104,22 +104,22 @@ Validation output should include:
 If `likelyAuthenticated` is anything other than `true`, do not continue to an
 authenticated scan and pretend the result is meaningful.
 
-## Staging Checklist: Form-Login Prepare And Validate
+## Authorized Target Checklist: Form-Login Prepare And Validate
 
-Use this checklist before calling an authenticated pilot ready. It is for
-staging/manual validation of form-login prepare and validate behavior, not for
-capturing real credentials in docs or tickets.
+Use this checklist before calling an authenticated pilot ready. It validates
+form-login prepare and validate behavior against any authorized target. It is
+not a reason to capture real credentials in docs or tickets.
 
 Operator profile:
 
-- `id=staging-form`
+- `id=target-form`
 - `kind=form`
-- `allowed-origin=https://staging.example.test`
-- `credential-reference=env:STAGING_SCAN_PASSWORD` or
+- `allowed-origin=https://app.example.test`
+- `credential-reference=env:TARGET_SCAN_PASSWORD` or
   `credential-reference=file:/absolute/path/to/mounted/secret`
 - credential references are exact; wildcards and inline secrets are not supported
-- derived ZAP context `staging-form-auth` (profile ID plus `-auth`)
-- `login-url=https://staging.example.test/login`
+- derived ZAP context `target-form-auth` (profile ID plus `-auth`)
+- `login-url=https://app.example.test/login`
 - `username=<scan-user-name>`
 - `username-field=<login-form-username-field>`
 - `password-field=<login-form-password-field>`
@@ -130,15 +130,15 @@ Operator profile:
 
 Inputs to prepare:
 
-- `profileId=staging-form`
-- `targetUrl=https://staging.example.test`
+- `profileId=target-form`
+- `targetUrl=https://app.example.test`
 
 Expected prepare evidence:
 
 - response starts with `Guided auth session prepared.`
-- response includes `Auth Profile: staging-form`
+- response includes `Auth Profile: target-form`
 - response includes `Auth Kind: form`
-- response includes `Authorized Origin: https://staging.example.test`
+- response includes `Authorized Origin: https://app.example.test`
 - response includes `Provider: zap-form-login`
 - response includes `Engine Binding: ZAP context/user ready`
 - response includes `Context ID:` and `User ID:`

--- a/docs/src/content/docs/getting-started/authentication-quick-start.md
+++ b/docs/src/content/docs/getting-started/authentication-quick-start.md
@@ -1,120 +1,140 @@
 ---
-title: "Authentication Quick Start Guide"
+title: "MCP Access Authentication"
 editUrl: false
-description: "Choose your authentication mode in 60 seconds."
+description: "Choose how Cursor, Open WebUI, or another MCP client authenticates to MCP ZAP Server."
 ---
-Choose your authentication mode in 60 seconds.
+This page configures access from Cursor, Open WebUI, or another MCP client to
+MCP ZAP Server. It does not configure ZAP to log in to the website being
+scanned.
+
+| Layer | Credential | Guide |
+| --- | --- | --- |
+| MCP client to MCP ZAP Server | API key or JWT | This page |
+| ZAP to an authorized target website | Optional website test account | [Form-Login Target Authentication](../form-login-target-authentication/) |
 
 For the shipped HTTP/server defaults, the base runtime starts in `api-key`. Use `none` only as an explicit local dev/test override.
 
-## 🚀 Quick Setup
+## Choose A Mode
 
-### Step 1: Choose Your Mode
+Edit `.env` and choose one of these configurations.
 
-Edit `.env` file:
+For the recommended API-key default:
 
 ```bash
-# Option 1: No Authentication (dev only)
-MCP_SECURITY_MODE=none
-
-# Option 2: API Key (simple)
 MCP_SECURITY_MODE=api-key
-MCP_API_KEY=your-secure-key-here
+MCP_API_KEY=replace-with-generated-api-key
+```
 
-# Option 3: JWT (shared or production-oriented deployments)
+For JWT in a deployment that manages token lifecycle:
+
+```bash
 MCP_SECURITY_MODE=jwt
 JWT_ENABLED=true
 JWT_SECRET=your-256-bit-secret-minimum-32-chars
-MCP_API_KEY=your-initial-key
+MCP_API_KEY=replace-with-bootstrap-api-key
 ```
 
-### Step 2: Generate Keys (if needed)
+For an isolated development test only:
 
 ```bash
-# Generate API key (Option 2 & 3)
+MCP_SECURITY_MODE=none
+```
+
+Generate credentials when needed:
+
+```bash
+# API-key and JWT bootstrap modes
 openssl rand -hex 32
 
-# Generate JWT secret (Option 3 only)
+# JWT signing secret
 openssl rand -base64 64
 ```
 
-### Step 3: Start Server
+Recreate the server after changing the mode:
 
 ```bash
-docker-compose up -d
+docker compose up -d --force-recreate mcp-server open-webui
 ```
 
-## 📝 Usage Examples
+Also update the credential in Cursor or any other client. Open WebUI receives
+the API key when its container is created, which is why it is recreated here.
+If you choose JWT, configure a pre-issued bearer token in each client; see
+[MCP Client Authentication](../mcp-client-authentication/).
 
-### Mode 1: No Authentication
+## What The Client Sends
 
-```bash
-# Just call the endpoint
-curl http://localhost:7456/mcp
+### API Key
+
+```http
+X-API-Key: replace-with-generated-api-key
 ```
 
-⚠️ **Development only!**
+Recommended for the default local Compose and Cursor setup.
 
-### Mode 2: API Key
-
-```bash
-# Add X-API-Key header
-curl -H "X-API-Key: your-key" http://localhost:7456/mcp
-```
-
-✅ **Good for simple deployments**
-
-### Mode 3: JWT
+### JWT
 
 ```bash
-# 1. Get token
-TOKEN=$(curl -X POST http://localhost:7456/auth/token \
+TOKEN=$(curl -fsS -X POST http://localhost:7456/auth/token \
   -H "Content-Type: application/json" \
-  -d '{"apiKey":"your-key","clientId":"client-1"}' | jq -r .accessToken)
-
-# 2. Use token
-curl -H "Authorization: Bearer $TOKEN" http://localhost:7456/mcp
+  -d '{"apiKey":"replace-with-bootstrap-api-key"}' | jq -r .accessToken)
 ```
 
-✅ **Best for shared deployments**
+The MCP client then sends:
 
-## 🔄 Quick Comparison
+```http
+Authorization: Bearer <access-token>
+```
 
-| Feature | None | API Key | JWT |
-|---------|------|---------|-----|
-| Setup Time | 10 sec | 30 sec | 60 sec |
-| Security | ❌ None | ⚠️ Basic | ✅ Strong |
-| Token Expiry | N/A | Never | 1 hour |
-| Use Case | Dev | Internal | Shared deployments |
+JWT is useful only when the deployment or client handles token issuance,
+expiry, refresh, and revocation. Cursor can send a pre-issued token but does not
+manage that lifecycle for this server.
 
-## 📚 Need More?
+### None
 
-- **Complete Guide**: [Security Modes](../security-modes/)
-- **JWT Details**: [JWT Authentication](../security-modes/jwt-authentication/)
-- **Client Setup**: [MCP Client Authentication](mcp-client-authentication/)
+No access credential is required. Never expose this mode to other users or
+networks.
 
-## 🆘 Troubleshooting
+## Comparison
+
+| Mode | Credential model | Recommended use |
+| --- | --- | --- |
+| `api-key` | Long-lived shared secret, rotate operationally | Default local Compose, Cursor, and small trusted deployments |
+| `jwt` | Signed access and refresh tokens with expiry/revocation | Shared deployments with token lifecycle support |
+| `none` | No client authentication | Isolated development tests only |
+
+## Next Reading
+
+- [Self-Serve First Run](../self-serve-first-run/)
+- [Cursor And MCP Client Setup](../mcp-client-authentication/)
+- [Optional Website Form-Login](../form-login-target-authentication/)
+- [Security Modes](../../security-modes/)
+- [JWT Authentication](../../security-modes/jwt-authentication/)
+
+## Troubleshooting
 
 ### "401 Unauthorized"
+
 - **Mode `api-key`**: Check `X-API-Key` header matches `.env`
 - **Mode `jwt`**: Token might be expired, get new one
 
 ### "Security is disabled" warning
-- You're in `none` mode - change to `api-key` or `jwt` for shared deployments
+
+You are in `none` mode. Change to `api-key` or `jwt` before allowing any other
+user or network to reach the server.
 
 ### Environment variables not loading
+
 ```bash
 # Recreate containers to pick up .env changes
-docker-compose down
-docker-compose up -d
+docker compose up -d --force-recreate mcp-server open-webui
 ```
 
-## 🎯 Recommendation
+## Recommendation
 
-- **Local Dev**: Use `none` mode
-- **Docker Compose**: Use `api-key` mode  
-- **Cloud/shared deployments**: Use `jwt` mode
+- **Default local Docker Compose and Cursor**: use `api-key` mode.
+- **Shared deployments with token lifecycle support**: consider `jwt` mode.
+- **Isolated development tests only**: use `none` only when authentication itself would block the test.
 
----
-
-**Time Investment**: 1 minute setup -> stronger deployment posture
+Your MCP access mode does not change whether the scan target is public or
+requires its own login. Configure target authentication only when the target
+actually needs it.

--- a/docs/src/content/docs/getting-started/form-login-target-authentication.md
+++ b/docs/src/content/docs/getting-started/form-login-target-authentication.md
@@ -1,0 +1,347 @@
+---
+title: "Optional: Form-Login Target Authentication"
+editUrl: false
+description: "Configure a website login for ZAP, validate it from Cursor, and use it with the guided HTTP crawl and active scan paths."
+---
+
+Skip this guide unless the application you are authorized to scan requires a
+straightforward username/password form login. Public pages and unauthenticated
+APIs work without any auth profile.
+
+## First, Separate The Two Authentication Layers
+
+| Credential | What it authenticates | Where it belongs |
+| --- | --- | --- |
+| MCP API key or JWT | Cursor to MCP ZAP Server | Cursor's `X-API-Key` or `Authorization` header |
+| Website username/password | ZAP to the authorized target | A server-side auth profile and mounted secret |
+
+These layers are independent. JWT remains fully valid for MCP access; it does
+not log ZAP in to the website. Never put the target website password in Cursor,
+`mcp.json`, a prompt, or a tool argument. Cursor supplies only a profile ID and
+target URL.
+
+ZAP provides the form-login engine, contexts, users, session handling, and
+scan-as-user capabilities. MCP ZAP Server securely configures and orchestrates
+those ZAP features through an operator-managed profile. This project did not
+build a second login engine from scratch.
+
+## What Works Today
+
+| Target authentication | Prepare and validate | Guided crawl and attack use it |
+| --- | --- | --- |
+| Traditional HTML username/password form | Yes | Yes, with the HTTP spider and active scan |
+| Target bearer token | Credential reference only | No automatic header injection yet |
+| Target API key | Credential reference only | No automatic header injection yet |
+| OAuth, SSO, MFA, CAPTCHA, or browser-only login | No | No |
+
+The guided form provider is for a classic URL-encoded form with predictable
+username and password fields. Dynamic CSRF tokens, multi-step flows, JSON login
+APIs, and JavaScript-heavy single-page applications may require a future
+browser/client-script provider or ZAP's expert controls. ZAP itself recommends
+[browser-based or client-script authentication for modern flows](https://www.zaproxy.org/blog/2025-07-03-authentication-improvements/).
+
+The profile workflow is newer than the published `v0.9.1` image. Use a build
+whose source contains `mcp.server.auth.bootstrap.profiles`; `v0.9.1` does not
+contain this contract.
+
+## Before You Start
+
+Complete [Self-Serve First Run](../self-serve-first-run/) first. Confirm that
+Cursor can list the guided ZAP tools using the MCP API key or JWT you chose.
+
+For the target application, gather:
+
+| Value | Example | Rule |
+| --- | --- | --- |
+| Profile ID | `local-form-app` | A stable label using letters, numbers, dots, underscores, or dashes |
+| Allowed origin | `http://host.docker.internal:8080` | Scheme, host, and optional port only; no path |
+| Target URL | `http://host.docker.internal:8080/account` | Must use exactly the same origin |
+| Login URL | `http://host.docker.internal:8080/login` | Must use exactly the same origin |
+| Scan username | `dedicated-zap-scan-user` | Use a dedicated, least-privilege test account |
+| Username field | `username` | The form input's HTML `name`, not its label or `id` |
+| Password field | `password` | The form input's HTML `name`, not its label or `id` |
+| Logged-in indicator | `Logout` | Stable response text present only after successful login |
+| Logged-out indicator | `Sign in` | Optional stable response text that proves login was lost |
+
+For example, this form uses `email` and `password` as the field names:
+
+```html
+<form action="/login" method="post">
+  <input name="email" type="email">
+  <input name="password" type="password">
+</form>
+```
+
+Choose the URL that the containers can reach:
+
+| Where the target runs | Use in the profile and Cursor |
+| --- | --- |
+| On your laptop, port 8080 | `http://host.docker.internal:8080` |
+| In the same Compose project as service `my-app`, port 8080 | `http://my-app:8080` |
+| On an authorized remote host | Its real `https://...` origin |
+
+`localhost` inside MCP Server or ZAP means that container, not your laptop.
+On native Linux, `host.docker.internal` resolves through the Docker gateway,
+but it cannot reach a target that listens only on host `127.0.0.1`. Bind the
+target to a Docker-reachable host interface and use firewall rules to keep that
+listener off untrusted networks.
+
+## 1. Create The Non-Secret Profile
+
+From the repository root:
+
+```bash
+AUTH_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/mcp-zap-server/auth"
+install -d -m 700 "$AUTH_HOME"
+cp examples/authenticated-scanning/auth-profiles.example.yml \
+  "$AUTH_HOME/auth-profiles.yml"
+```
+
+Edit `$AUTH_HOME/auth-profiles.yml` and replace every target-specific value.
+The checked-in example describes an application running on your laptop at port
+8080. It is not a bundled demo target.
+
+When editing the profile, remember:
+
+- `allowed-origin` has no path and must exactly match the scheme, host, and port
+  of both `login-url` and the `targetUrl` you will use in Cursor.
+- Do not add a terminal dot to a hostname.
+- Keep `credential-reference` set to
+  `file:/run/secrets/target_form_password` for this Compose example.
+- The logged-in indicator must be visible in the response ZAP receives, not
+  text inserted later only by browser JavaScript.
+
+Make the final non-secret configuration readable by the container but not
+writable:
+
+```bash
+chmod 0444 "$AUTH_HOME/auth-profiles.yml"
+```
+
+## 2. Create The Password File
+
+The following reads the password without echoing it or putting it in shell
+history:
+
+```bash
+AUTH_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/mcp-zap-server/auth"
+printf 'Target test-account password: ' >&2
+IFS= read -r -s TARGET_FORM_PASSWORD
+printf '\n' >&2
+if [ -z "$TARGET_FORM_PASSWORD" ]; then
+  printf 'Password cannot be empty; no secret file was written.\n' >&2
+  unset TARGET_FORM_PASSWORD
+else
+  (umask 077; printf '%s' "$TARGET_FORM_PASSWORD" > "$AUTH_HOME/target-form-password")
+  unset TARGET_FORM_PASSWORD
+  chmod 0444 "$AUTH_HOME/target-form-password"
+fi
+```
+
+The credential resolver trims leading and trailing whitespace. A target
+password that intentionally begins or ends with whitespace is not supported by
+this profile path.
+
+The `0444` file mode is intentional for the default local Compose path. The
+containing directory is `0700`, while the individual bind-mounted files must be
+readable by the non-root container user (UID/GID 1000). Compose file-backed
+secrets do not remap host file ownership. See Docker's
+[Compose secrets reference](https://docs.docker.com/reference/compose-file/services/#secrets).
+
+## 3. Point Compose At The Files
+
+Add these two entries to the repository's ignored `.env` file, using fully
+expanded absolute paths from your machine:
+
+```dotenv
+MCP_ZAP_AUTH_PROFILES_FILE=/Users/you/.config/mcp-zap-server/auth/auth-profiles.yml
+MCP_ZAP_FORM_PASSWORD_FILE=/Users/you/.config/mcp-zap-server/auth/target-form-password
+```
+
+Do not use `~` or `$HOME` in `.env`; Compose does not recursively shell-expand
+those values. Keep `.env` private because it already contains the MCP and ZAP
+API keys:
+
+```bash
+chmod 0600 .env
+```
+
+## 4. Render And Start The Optional Setup
+
+Always use the same three Compose files while target authentication is enabled:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  config --quiet
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  up -d --build --force-recreate --wait
+```
+
+The override adds `host.docker.internal` support to both MCP Server and ZAP,
+mounts the non-secret profile, and mounts the password as a Compose secret.
+
+Do not run `./dev.sh` while this optional profile is enabled. That script does
+not load the override and can recreate `mcp-server` without the profile.
+
+## 5. Check The Wiring Without Printing Secrets
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  exec -T mcp-server sh -c \
+  'test -r /app/auth-profiles.yml &&
+   test -r /run/secrets/target_form_password &&
+   test -s /run/secrets/target_form_password'
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  exec -T zap curl -fsS -o /dev/null \
+  http://host.docker.internal:8080/login
+
+./bin/self-serve-doctor.sh
+```
+
+The doctor proves MCP and ZAP connectivity. It does not prove the target login.
+Profiles are loaded when MCP Server starts, so a health check alone is not
+evidence that the profile or password is correct.
+
+Replace the preflight login URL if your target is not the host-port example. A
+successful GET proves only that ZAP can reach the login route; Cursor's prepare
+and validate flow still has to prove authentication.
+
+## 6. Prepare And Validate From Cursor
+
+Give Cursor this prompt, replacing the profile and target URL if you changed
+them:
+
+```text
+Use only the guided ZAP tools.
+
+Prepare target form-login authentication with profile `local-form-app` for
+http://host.docker.internal:8080/account.
+
+Validate the returned auth session. Stop and report the diagnostics unless the
+result contains all three lines:
+Valid: true
+Outcome: authenticated
+likelyAuthenticated=true
+
+If validation succeeds, start an HTTP crawl against the same origin using the
+returned authSessionId. Poll until complete, wait for passive analysis, and
+summarize the findings. Do not start an active scan.
+
+Never ask for or echo the target website password.
+```
+
+Preparation should also report:
+
+```text
+Provider: zap-form-login
+Engine Binding: ZAP context/user ready
+```
+
+Treat anything other than `likelyAuthenticated=true` as failure. Validation is
+a required operator/agent workflow step; scan start does not currently enforce
+that you called validation first.
+
+After the crawl, confirm at least one page that genuinely requires login was
+reached. A green login check plus public-only crawl coverage is not enough to
+claim an authenticated scan.
+
+Treat the returned auth session ID as a sensitive, process-local capability.
+Do not paste it into tickets or logs. It disappears when MCP Server restarts.
+
+## 7. Optionally Approve An Active Scan
+
+Active scanning can change data, send destructive inputs, or trigger side
+effects. It is never implied by this setup. When the target owner has approved
+it, use a separate prompt:
+
+```text
+Using the already prepared and validated form-login auth session, start a
+guided active scan against http://host.docker.internal:8080/account. Use the same
+authSessionId and exact origin. Poll until complete, wait for passive analysis,
+then summarize findings. Stop if the auth session is missing or invalid.
+```
+
+The authorized target may be local, in a private cloud, or in Kubernetes. MCP
+ZAP Server does not require anyone to call it "staging" or "production".
+
+The guided ZAP context covers the profile's entire allowed origin, even if the
+Cursor target URL contains a narrower path. Only the origin's root `/logout`
+path is excluded automatically. If the application uses another logout route
+or has destructive account-management endpoints, do not approve an active
+scan until those paths are controlled through target-side safeguards or an
+expert ZAP context.
+
+## Changing Or Removing The Profile
+
+Profile configuration, password rotation, and prepared sessions are process
+state. After changing the profile or password, recreate `mcp-server`, then
+prepare and validate a new session.
+
+The example files are read-only after setup. For a rotation, temporarily make
+them writable, update the profile and/or replace the password using Steps 1 and
+2, restore the read-only mode, and recreate only MCP Server:
+
+```bash
+AUTH_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/mcp-zap-server/auth"
+chmod 0600 "$AUTH_HOME/auth-profiles.yml" "$AUTH_HOME/target-form-password"
+# Edit auth-profiles.yml and/or repeat the password-entry block from Step 2.
+chmod 0444 "$AUTH_HOME/auth-profiles.yml" "$AUTH_HOME/target-form-password"
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  up -d --force-recreate --no-deps --wait mcp-server
+```
+
+To return to the normal unauthenticated-target quick start:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  down
+./dev.sh
+```
+
+Your MCP API key or JWT setup does not change either way.
+
+## Troubleshooting
+
+| Symptom | Meaning | Fix |
+| --- | --- | --- |
+| Cursor gets `401 Unauthorized` | MCP access authentication failed | Fix Cursor's `X-API-Key` or bearer token; this is not a target-login problem |
+| Cursor gets `403 Forbidden` on an auth or scan tool | The MCP principal lacks the required tool scope | Grant the appropriate auth/scan scope or use the default local API-key client |
+| `Unknown auth profile ID` | The profile is absent or MCP Server was not recreated | Check the mounted file and restart with all three Compose files |
+| `Auth profile credential could not be resolved` | The secret is missing or unreadable inside the container | Run the non-secret readability check and verify the absolute host path |
+| Target origin is not authorized | Scheme, host, or port differs | Make `allowed-origin`, `login-url`, and Cursor's target URL use the same exact origin |
+| `authentication_failed` | Credentials, form fields, indicators, or the auth flow are wrong | Verify the test account and inspect the actual form `name` attributes and response text |
+| Browser strategy rejects auth | Guided authenticated crawl supports HTTP spider only | Use `strategy: http`; do not use AJAX/browser strategy with `authSessionId` |
+| Session becomes unknown after restart | Prepared sessions are held in memory | Prepare and validate a new session |
+| Header profile validates but the crawl is anonymous | Target bearer/API-key injection is not implemented | Do not use header profiles as authenticated scan evidence |
+
+If the login uses OAuth, SSO, MFA, CAPTCHA, dynamic CSRF handling, or a
+JavaScript/JSON flow, stop forcing it through this provider. That is an
+unsupported flow, not a documentation typo.
+
+## Next Reading
+
+- [MCP Client Authentication](../mcp-client-authentication/) for Cursor API-key or JWT setup
+- [MCP Client Scan To Evidence](../../scanning/mcp-client-scan-to-evidence/) for the full guided workflow
+- [Authenticated Scanning Reference](../../scanning/authenticated-scanning-best-practices/) for advanced deployment and expert ZAP controls
+- [ZAP authentication concepts](https://www.zaproxy.org/docs/getting-further/authentication/concepts/) for the underlying engine model

--- a/docs/src/content/docs/getting-started/jwt-quick-start.md
+++ b/docs/src/content/docs/getting-started/jwt-quick-start.md
@@ -157,7 +157,7 @@ Common causes:
 
 ## Next Steps
 
-- read the [full JWT guide](../security-modes/jwt-authentication/)
-- configure client scopes with [Tool Scope Authorization](./tool-scope-authorization/)
-- choose the right [Tool Surface](./tool-surfaces/)
-- configure your real client with [MCP Client Authentication](./mcp-client-authentication/)
+- read the [full JWT guide](../../security-modes/jwt-authentication/)
+- configure client scopes with [Tool Scope Authorization](../tool-scope-authorization/)
+- choose the right [Tool Surface](../tool-surfaces/)
+- configure your real client with [MCP Client Authentication](../mcp-client-authentication/)

--- a/docs/src/content/docs/getting-started/mcp-client-authentication.md
+++ b/docs/src/content/docs/getting-started/mcp-client-authentication.md
@@ -3,6 +3,11 @@ title: "MCP Client Authentication"
 editUrl: false
 description: "Configure MCP clients for API-key or bearer-token access to the streamable HTTP endpoint."
 ---
+This page authenticates Cursor, Open WebUI, or another MCP client to MCP ZAP
+Server. It does not authenticate ZAP to the website being scanned. If the
+target itself requires a username/password form, finish the client connection
+here first, then use [Form-Login Target Authentication](../form-login-target-authentication/).
+
 This server exposes a streamable HTTP MCP endpoint at:
 
 ```text
@@ -17,7 +22,7 @@ The server supports:
 
 The practical truth: API-key mode is still the easiest self-serve client setup. Not every MCP desktop client handles remote HTTP transport, custom auth headers, or JWT refresh the same way.
 
-If you are starting from a fresh clone, use [Self-Serve First Run](./self-serve-first-run/) before tuning client-specific details here.
+If you are starting from a fresh clone, use [Self-Serve First Run](../self-serve-first-run/) before tuning client-specific details here.
 
 ## Recommended Paths
 
@@ -27,7 +32,8 @@ Use one of these paths:
 2. Cursor or another MCP client that supports streamable HTTP plus custom headers
 3. a custom client or script that can call the MCP endpoint directly
 
-This repository does not ship first-party desktop proxy helpers. Older proxy examples were fiction-by-documentation and needed to die.
+This repository does not ship a first-party desktop proxy helper. Use the
+direct streamable HTTP endpoint with a client that supports custom headers.
 
 ## Open WebUI
 
@@ -86,6 +92,9 @@ If you prefer a static bearer token instead of `X-API-Key`:
 
 Use API-key mode unless you already have a reason to manage token issuance outside Cursor.
 
+The API key or bearer token in `mcp.json` is only the MCP access credential.
+Never add the target website username or password to this file.
+
 ## Generic Streamable HTTP Clients
 
 Any MCP client that supports:
@@ -122,7 +131,9 @@ Claude Desktop's remote MCP flow is different from Cursor's:
 
 Because of that, Open WebUI or Cursor is the recommended self-serve path today.
 
-If you need first-class Claude Desktop remote onboarding, the right fix is not another ad hoc proxy snippet. The right fix is a supported auth path that matches Claude's connector model.
+First-class Claude Desktop remote onboarding would require an authentication
+path that matches Claude's connector model; an ad hoc local proxy is not a
+supported substitute.
 
 ## JWT Guidance
 
@@ -134,7 +145,7 @@ JWT is supported by the server, but desktop-client ergonomics depend on the clie
 
 That is why API-key mode remains the recommended self-serve option for local Compose, Open WebUI, and Cursor.
 
-For server-side JWT setup, see [JWT Setup](../security-modes/jwt-authentication/).
+For server-side JWT setup, see [JWT Setup](../../security-modes/jwt-authentication/).
 
 ## Test The Endpoint Manually
 
@@ -195,6 +206,14 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" \
 - initialize the MCP session first if you are testing manually
 - reuse the returned `Mcp-Session-Id` header on later requests
 
+### Cursor Connects But Target Login Fails
+
+That is a separate ZAP-to-target authentication problem. Keep the Cursor API
+key or JWT unchanged and follow
+[Form-Login Target Authentication](../form-login-target-authentication/).
+
 ### Claude Desktop Setup Feels Inconsistent
 
-That is because Claude's remote connector flow and generic JSON config examples on the internet are not the same thing. For this repository today, prefer Open WebUI or Cursor unless you are intentionally building a Claude-specific remote connector path.
+Claude's remote connector flow and generic JSON configuration examples are not
+the same thing. For this repository today, prefer Open WebUI or Cursor unless
+you are intentionally building a Claude-specific remote connector path.

--- a/docs/src/content/docs/getting-started/self-serve-first-run.md
+++ b/docs/src/content/docs/getting-started/self-serve-first-run.md
@@ -77,10 +77,20 @@ tool call.
 - The default Compose stack wires Open WebUI to the local MCP server with the
   generated API key.
 
-## 5. Use The Guided Happy Path
+## 5. Decide Whether The Target Needs Login
+
+Most first runs should skip target authentication. The bundled Juice Shop and
+Petstore examples can be scanned without an auth profile.
+
+If your authorized target requires a traditional username/password HTML form,
+use [Form-Login Target Authentication](../form-login-target-authentication/).
+That optional setup is separate from the API key or JWT used by Cursor. Never
+put the website password in Cursor or an MCP prompt.
+
+## 6. Use The Guided Happy Path
 
 For the full target-to-evidence workflow, use the
-[MCP Client Scan-To-Evidence Guide](../scanning/mcp-client-scan-to-evidence/).
+[MCP Client Scan-To-Evidence Guide](../../scanning/mcp-client-scan-to-evidence/).
 
 Use prompts like these:
 
@@ -93,7 +103,7 @@ Use prompts like these:
 That is enough to prove the end-to-end self-serve path without dragging a new
 user through every advanced feature in the repo.
 
-## 6. If It Breaks
+## 7. If It Breaks
 
 Use this order:
 

--- a/docs/src/content/docs/getting-started/tool-scope-authorization.md
+++ b/docs/src/content/docs/getting-started/tool-scope-authorization.md
@@ -129,4 +129,4 @@ Normal MCP clients handle this automatically.
 - disable wildcard scopes once migration is complete
 - review scope grants when you switch from `guided` to `expert`
 
-For surface selection, see [Tool Surfaces](./tool-surfaces/).
+For surface selection, see [Tool Surfaces](../tool-surfaces/).

--- a/docs/src/content/docs/getting-started/tool-surfaces.md
+++ b/docs/src/content/docs/getting-started/tool-surfaces.md
@@ -97,22 +97,23 @@ These docs now call out expert-only pages explicitly.
 
 Pages that matter to almost everyone:
 
-- [Authentication Quick Start](./authentication-quick-start/)
-- [MCP Client Authentication](./mcp-client-authentication/)
-- [JWT Quick Start](./jwt-quick-start/)
-- [Tool Scope Authorization](./tool-scope-authorization/)
-- [Scan Execution Modes](../scanning/scan-execution-modes/)
-- [Authenticated Scanning Best Practices](../scanning/authenticated-scanning-best-practices/)
-- [Passive Scan](../scanning/passive-scan/)
-- [Scan History Ledger](../operations/scan-history-ledger/)
+- [MCP Access Authentication](../authentication-quick-start/)
+- [MCP Client Authentication](../mcp-client-authentication/)
+- [Optional Target Form-Login](../form-login-target-authentication/)
+- [JWT Quick Start](../jwt-quick-start/)
+- [Tool Scope Authorization](../tool-scope-authorization/)
+- [Scan Execution Modes](../../scanning/scan-execution-modes/)
+- [Authenticated Scanning Reference](../../scanning/authenticated-scanning-best-practices/)
+- [Passive Scan](../../scanning/passive-scan/)
+- [Scan History Ledger](../../operations/scan-history-ledger/)
 
 Pages that require `expert`:
 
-- [AJAX Spider](../scanning/ajax-spider/)
-- [API Schema Imports](../scanning/api-schema-imports/)
-- [Scan Policy Controls](../scanning/scan-policy-controls/)
-- [Findings and Reports](../scanning/findings-and-reports/)
-- [Automation Framework](../scanning/automation-framework/)
+- [AJAX Spider](../../scanning/ajax-spider/)
+- [API Schema Imports](../../scanning/api-schema-imports/)
+- [Scan Policy Controls](../../scanning/scan-policy-controls/)
+- [Findings and Reports](../../scanning/findings-and-reports/)
+- [Automation Framework](../../scanning/automation-framework/)
 
 ## Recommendation
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -70,6 +70,10 @@ editUrl: false
       <h3>&gt; [07] EXTENSION_POLICY</h3>
       <p>See what must be true before the extension API becomes a public compatibility promise.</p>
     </a>
+    <a class="mission-card" href="./getting-started/form-login-target-authentication/">
+      <h3>&gt; [OPTIONAL] TARGET_FORM_LOGIN</h3>
+      <p>Only when the authorized target requires it: let ZAP log in without exposing the password to Cursor.</p>
+    </a>
   </div>
 
   <span class="section-label">tail -f /var/log/capabilities.txt</span>

--- a/docs/src/content/docs/operations/production-simulation-runbook.md
+++ b/docs/src/content/docs/operations/production-simulation-runbook.md
@@ -19,7 +19,7 @@ real support boundary:
 
 ## Preconditions
 
-- [Production Readiness Checklist](./production-checklist/) is materially
+- [Production Readiness Checklist](../production-checklist/) is materially
   complete.
 - Runtime secrets come from a secret manager or Kubernetes Secret references.
 - ZAP remains private-only.
@@ -183,6 +183,6 @@ Principal engineering sign-off:
 
 ## Related Docs
 
-- [Production Readiness Checklist](./production-checklist/)
-- [Release Evidence Handoff Runbook](./release-evidence-handoff-runbook/)
-- [Queue Coordinator and Worker Claims](./queue-coordinator-leader-election/)
+- [Production Readiness Checklist](../production-checklist/)
+- [Release Evidence Handoff Runbook](../release-evidence-handoff-runbook/)
+- [Queue Coordinator and Worker Claims](../queue-coordinator-leader-election/)

--- a/docs/src/content/docs/operations/release-evidence-handoff-runbook.md
+++ b/docs/src/content/docs/operations/release-evidence-handoff-runbook.md
@@ -159,6 +159,6 @@ Date:
 
 ## Related Docs
 
-- [Scan History Ledger](./scan-history-ledger/)
-- [Production Readiness Checklist](./production-checklist/)
-- [Production Simulation Runbook](./production-simulation-runbook/)
+- [Scan History Ledger](../scan-history-ledger/)
+- [Production Readiness Checklist](../production-checklist/)
+- [Production Simulation Runbook](../production-simulation-runbook/)

--- a/docs/src/content/docs/operations/scan-history-ledger.md
+++ b/docs/src/content/docs/operations/scan-history-ledger.md
@@ -138,4 +138,4 @@ Before relying on the ledger for release evidence:
    customer, design partner, or pilot reviewer needs a readable summary.
 
 For the exact handoff sequence and sign-off template, use
-[Release Evidence Handoff Runbook](./release-evidence-handoff-runbook/).
+[Release Evidence Handoff Runbook](../release-evidence-handoff-runbook/).

--- a/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
+++ b/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
@@ -1,15 +1,20 @@
 ---
-title: "Authenticated Scanning Best Practices"
+title: "Authenticated Scanning Reference"
 editUrl: false
-description: "Prepare, validate, and use guided authenticated scan sessions safely."
+description: "Advanced deployment, migration, validation, and expert guidance for authenticated scans."
 ---
+This is the advanced operator reference. If this is your first target that
+requires login, start with
+[Optional: Form-Login Target Authentication](../../getting-started/form-login-target-authentication/)
+for the local Compose setup and a Cursor-ready example.
+
 Authenticated scans are where most business-critical vulnerabilities live. They are also where teams most often fool themselves.
 
 If authentication is not proven immediately before the crawl or attack, the scan is usually just an unauthenticated scan wearing a nicer label.
 
 ## Recommended Path
 
-For 0.7.0 and later, start with guided auth bootstrap:
+In current development builds, start with guided auth bootstrap:
 
 - `zap_auth_session_prepare`
 - `zap_auth_session_validate`
@@ -17,6 +22,10 @@ For 0.7.0 and later, start with guided auth bootstrap:
 - `zap_attack_start` with `authSessionId`
 
 These tools are available on the default `guided` surface. The lower-level ZAP context and user tools still exist on the `expert` surface, but they are the advanced path now.
+
+The profile contract is newer than the published `v0.9.1` image. Traditional
+form-login support is limited to the HTTP spider and active scan paths; it does
+not imply OAuth, SSO, MFA, CAPTCHA, or JavaScript-heavy browser login support.
 
 Treat guided profile contexts as managed state. Do not alter a returned context with expert auth tools; fix the profile and prepare a new session instead.
 
@@ -39,10 +48,10 @@ mcp:
     auth:
       bootstrap:
         profiles:
-          - id: shop-staging
+          - id: shop-form
             kind: form
             allowed-origin: https://shop.example.com
-            credential-reference: env:STAGING_SCAN_PASSWORD
+            credential-reference: env:TARGET_SCAN_PASSWORD
             login-url: https://shop.example.com/login
             username: zap-scan-user
             zap-user-name: zap-scan-user
@@ -82,10 +91,10 @@ mcp:
     auth:
       bootstrap:
         profiles:
-          - id: shop-staging
+          - id: shop-form
             kind: form
             allowed-origin: https://shop.example.com
-            credential-reference: ${SHOP_SCAN_CREDENTIAL_REFERENCE:env:SHOP_SCAN_PASSWORD}
+            credential-reference: ${TARGET_SCAN_CREDENTIAL_REFERENCE:env:TARGET_SCAN_PASSWORD}
             login-url: https://shop.example.com/login
             username: zap-scan-user
             username-field: username
@@ -100,10 +109,10 @@ Inject the password through the existing service manager or secret store. This
 foreground example avoids placing it in shell history:
 
 ```bash
-printf 'Shop scan password: ' >&2
-IFS= read -r -s SHOP_SCAN_PASSWORD
+printf 'Target scan password: ' >&2
+IFS= read -r -s TARGET_SCAN_PASSWORD
 printf '\n' >&2
-export SHOP_SCAN_PASSWORD
+export TARGET_SCAN_PASSWORD
 
 ./gradlew bootJar
 APP_VERSION=$(./gradlew -q properties | awk '/^version:/ {print $2}')
@@ -120,39 +129,31 @@ that restart.
 ### Docker Compose
 
 Keep the password in a host file outside the repository, readable by Docker, and
-use a Compose secret rather than a container environment variable. Create
-`docker-compose.auth-profile.yml` in the repository root:
+use a Compose secret rather than a container environment variable. Reuse the
+checked-in
+[`auth-profiles.example.yml`](https://github.com/dtkmn/mcp-zap-server/blob/main/examples/authenticated-scanning/auth-profiles.example.yml)
+and
+[`docker-compose.auth-profile.yml`](https://github.com/dtkmn/mcp-zap-server/blob/main/examples/authenticated-scanning/docker-compose.auth-profile.yml)
+instead of maintaining another copy of the override. Copy and edit the profile
+outside the repository first.
 
-```yaml
-services:
-  mcp-server:
-    environment:
-      SPRING_CONFIG_ADDITIONAL_LOCATION: file:/app/config/auth-profiles.yml
-      SHOP_SCAN_CREDENTIAL_REFERENCE: file:/run/secrets/shop_scan_password
-    volumes:
-      - ${AUTH_PROFILES_FILE:?set AUTH_PROFILES_FILE}:/app/config/auth-profiles.yml:ro
-    secrets:
-      - shop_scan_password
-
-secrets:
-  shop_scan_password:
-    file: ${SHOP_SCAN_PASSWORD_FILE:?set SHOP_SCAN_PASSWORD_FILE}
-```
-
-Then validate the merged deployment and recreate the MCP container:
+Set fully expanded absolute paths, validate the merged deployment, and recreate
+the MCP container:
 
 ```bash
-export AUTH_PROFILES_FILE=/etc/mcp-zap/auth-profiles.yml
-export SHOP_SCAN_PASSWORD_FILE=/run/operator-secrets/shop-staging-password
-test -r "$AUTH_PROFILES_FILE" && test -r "$SHOP_SCAN_PASSWORD_FILE"
+export MCP_ZAP_AUTH_PROFILES_FILE=/etc/mcp-zap/auth-profiles.yml
+export MCP_ZAP_FORM_PASSWORD_FILE=/run/operator-secrets/shop-form-password
+test -r "$MCP_ZAP_AUTH_PROFILES_FILE" && test -r "$MCP_ZAP_FORM_PASSWORD_FILE"
 
 docker compose \
   -f docker-compose.yml \
-  -f docker-compose.auth-profile.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
   config --quiet
 docker compose \
   -f docker-compose.yml \
-  -f docker-compose.auth-profile.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
   up -d --build --force-recreate --wait --wait-timeout 180 mcp-server
 ```
 
@@ -171,7 +172,7 @@ variable referenced by the profile:
 export NAMESPACE=mcp-zap
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n "$NAMESPACE" create secret generic mcp-zap-auth-profile \
-  --from-file=SHOP_SCAN_PASSWORD=/run/operator-secrets/shop-staging-password \
+  --from-file=TARGET_SCAN_PASSWORD=/run/operator-secrets/shop-form-password \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
@@ -188,10 +189,10 @@ mcp:
               "auth": {
                 "bootstrap": {
                   "profiles": [{
-                    "id": "shop-staging",
+                    "id": "shop-form",
                     "kind": "form",
                     "allowedOrigin": "https://shop.example.com",
-                    "credentialReference": "env:SHOP_SCAN_PASSWORD",
+                    "credentialReference": "env:TARGET_SCAN_PASSWORD",
                     "loginUrl": "https://shop.example.com/login",
                     "username": "zap-scan-user",
                     "usernameField": "username",
@@ -230,6 +231,10 @@ this migration. Replace the variable placeholder before running them. Do not use
 an empty value or `v0.9.1`; either choice deploys code without the profile migration
 contract.
 
+The repository does not contain a `production-values.yml`. The example below
+uses only the profile values file. If you maintain another values file, add its
+real path with another `-f` argument.
+
 Render before applying, then wait for the MCP rollout:
 
 ```bash
@@ -243,19 +248,16 @@ MCP_ZAP_IMAGE_TAG=sha-REPLACE_WITH_FULL_MAIN_COMMIT_SHA
 }
 
 helm lint helm/mcp-zap-server \
-  -f production-values.yml \
   -f auth-profile-values.yml \
   --set-string "mcp.image.tag=$MCP_ZAP_IMAGE_TAG"
 helm template mcp-zap helm/mcp-zap-server \
   --namespace "$NAMESPACE" \
-  -f production-values.yml \
   -f auth-profile-values.yml \
   --set-string "mcp.image.tag=$MCP_ZAP_IMAGE_TAG" \
   --show-only templates/mcp-deployment.yaml \
   | grep -E "^[[:space:]]+image: \"[^\"]+:${MCP_ZAP_IMAGE_TAG}\"$" >/dev/null
 helm upgrade --install mcp-zap helm/mcp-zap-server \
   --namespace "$NAMESPACE" \
-  -f production-values.yml \
   -f auth-profile-values.yml \
   --set-string "mcp.image.tag=$MCP_ZAP_IMAGE_TAG" \
   --atomic --wait
@@ -328,7 +330,7 @@ curl -sS --fail-with-body \
   -H 'Accept: application/json,text/event-stream' \
   -H 'Content-Type: application/json' \
   "$MCP_URL" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"zap_auth_session_prepare","arguments":{"profileId":"shop-staging","targetUrl":"https://shop.example.com"}}}' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"zap_auth_session_prepare","arguments":{"profileId":"shop-form","targetUrl":"https://shop.example.com"}}}' \
   >"$PREPARE_RAW"
 
 PREPARE_JSON=$(normalize_mcp_response "$PREPARE_RAW")
@@ -338,7 +340,7 @@ PREPARE_TEXT=$(printf '%s' "$PREPARE_JSON" | jq -er '
   if startswith("\"") and endswith("\"") then fromjson else . end
 ')
 printf '%s\n' "$PREPARE_TEXT" | grep -F 'Guided auth session prepared.'
-printf '%s\n' "$PREPARE_TEXT" | grep -F 'Auth Profile: shop-staging'
+printf '%s\n' "$PREPARE_TEXT" | grep -F 'Auth Profile: shop-form'
 printf '%s\n' "$PREPARE_TEXT" | grep -F 'Authorized Origin: https://shop.example.com'
 AUTH_SESSION_ID=$(printf '%s\n' "$PREPARE_TEXT" | sed -n 's/^Session ID: //p')
 test -n "$AUTH_SESSION_ID"
@@ -379,7 +381,7 @@ Use a dedicated least-privilege scan account and a tight target scope.
 {
   "tool": "zap_auth_session_prepare",
   "arguments": {
-    "profileId": "shop-staging",
+    "profileId": "shop-form",
     "targetUrl": "https://shop.example.com"
   }
 }
@@ -388,7 +390,7 @@ Use a dedicated least-privilege scan account and a tight target scope.
 The response should include:
 
 - `Session ID`
-- `Auth Profile: shop-staging`
+- `Auth Profile: shop-form`
 - `Auth Kind: form`
 - `Authorized Origin: https://shop.example.com`
 - `Provider: zap-form-login`
@@ -529,4 +531,5 @@ If `zap_auth_test_user` cannot prove the user is authenticated, the scan is not 
 - Header session validates but crawl is still unauthenticated: bearer/API-key header injection is not in the guided engine path yet.
 - Browser strategy rejects auth: authenticated browser/AJAX guided crawl is not supported yet.
 
-If you are debugging an incident, use the operator runbook at `docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md`.
+If you are debugging an incident, use the
+[Auth Bootstrap Failure Runbook](https://github.com/dtkmn/mcp-zap-server/blob/main/docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md).

--- a/docs/src/content/docs/scanning/mcp-client-scan-to-evidence.md
+++ b/docs/src/content/docs/scanning/mcp-client-scan-to-evidence.md
@@ -71,9 +71,12 @@ Use this for:
 Skip this when the target is a normal crawlable web app and you only need page
 discovery.
 
-### 2. Optional Auth Session
+### 2. Optional Target Authentication
 
-For simple auth, prepare and validate a guided auth session:
+Skip this step for public routes and unauthenticated APIs. If the authorized
+target has a traditional username/password HTML form, complete the
+[first-timer form-login setup](../../getting-started/form-login-target-authentication/),
+then prepare and validate a guided auth session:
 
 1. `zap_auth_session_prepare`
 2. `zap_auth_session_validate`
@@ -88,6 +91,10 @@ sessions. Bearer and API-key session preparation is useful as a contract and
 validation path, but do not assume every guided scan mode consumes those
 session types yet.
 
+The target's website password never belongs in the MCP client or prompt. The
+operator stores it in a mounted secret; MCP Server resolves it server-side to
+configure the corresponding ZAP user.
+
 ### 3. Start A Guided Crawl
 
 Call `zap_crawl_start`.
@@ -95,7 +102,7 @@ Call `zap_crawl_start`.
 Recommended parameters:
 
 - `targetUrl`: the container-reachable target, such as `http://juice-shop:3000`
-- `strategy`: `auto` for most first runs
+- `strategy`: `auto` for unauthenticated first runs; use `http` with a prepared form-login session
 - `authSessionId`: only when you prepared and validated a form-login session
 
 The response returns a guided `Operation ID`. Use that operation ID with
@@ -240,6 +247,18 @@ When the crawl completes, wait for passive analysis, then produce findings,
 report, release evidence, and customer handoff. Do not start an active scan.
 ```
 
+For a target with a configured form-login profile:
+
+```text
+Use only the guided ZAP tools. Prepare form-login profile `local-form-app` for
+http://host.docker.internal:8080/account and validate the returned session. Stop unless
+the result contains `Valid: true`, `Outcome: authenticated`, and
+`likelyAuthenticated=true`. If validation succeeds, start an HTTP crawl with
+the returned authSessionId, poll until complete, wait for passive analysis,
+and summarize findings. Never ask for or echo the website password. Do not
+start an active scan.
+```
+
 ## What The IDs Mean
 
 | ID | Why it appears | What to do with it |
@@ -298,11 +317,13 @@ Not today:
 | Client keeps asking for ZAP scan IDs | It is following expert guidance or old context. | Tell it to follow guided `Next Actions` and use guided operation IDs. |
 | Findings look empty immediately after scan | Passive analysis has not drained. | Run `zap_passive_scan_wait`, then check findings again. |
 | Handoff has caveats | Evidence window is incomplete or direct-only. | Review `zap_scan_history_release_evidence` warnings and rerun with stronger coverage if needed. |
-| Authenticated scan fails | Profile origin, login indicators, or configured credential reference is wrong. | Fix the operator-managed profile, then re-run `zap_auth_session_prepare` and `zap_auth_session_validate`. |
+| Authenticated scan fails | Profile origin, login indicators, form fields, or configured credential reference is wrong. | Use the [form-login troubleshooting guide](../../getting-started/form-login-target-authentication/#troubleshooting), fix the profile, then prepare and validate a new session. |
 
 ## Related Docs
 
 - [MCP Client Authentication](../../getting-started/mcp-client-authentication/)
+- [Form-Login Target Authentication](../../getting-started/form-login-target-authentication/)
+- [Authenticated Scanning Reference](../authenticated-scanning-best-practices/)
 - [Scan Execution Modes](../scan-execution-modes/)
 - [Passive Scan](../passive-scan/)
 - [Findings And Reports](../findings-and-reports/)

--- a/docs/src/content/docs/scanning/scan-execution-modes.md
+++ b/docs/src/content/docs/scanning/scan-execution-modes.md
@@ -119,7 +119,7 @@ After crawl or attack completion:
 2. run `zap_passive_scan_wait`
 3. then read findings or generate reports
 
-See [Passive Scan](./passive-scan/).
+See [Passive Scan](../passive-scan/).
 
 ## Recommendation
 

--- a/docs/src/content/docs/security-modes/examples.md
+++ b/docs/src/content/docs/security-modes/examples.md
@@ -386,7 +386,7 @@ docker-compose up -d
 
 ## 📚 Related Documentation
 
-- [Security Modes Guide](./) - Detailed comparison
-- [JWT Authentication](jwt-authentication/) - JWT implementation
-- [MCP Client Config](../getting-started/mcp-client-authentication/) - Client setup
-- [Quick Start](../getting-started/authentication-quick-start/) - 60-second setup
+- [Security Modes Guide](../) - Detailed comparison
+- [JWT Authentication](../jwt-authentication/) - JWT implementation
+- [MCP Client Config](../../getting-started/mcp-client-authentication/) - Client setup
+- [MCP Access Authentication](../../getting-started/authentication-quick-start/) - Mode selection

--- a/docs/src/content/docs/security-modes/jwt-authentication.md
+++ b/docs/src/content/docs/security-modes/jwt-authentication.md
@@ -173,7 +173,7 @@ That means:
 - switching from API key to JWT does not require rebuilding your authorization model
 - missing tool scopes still produce `403` even when authentication succeeds
 
-For scope setup, see [Tool Scope Authorization](../getting-started/tool-scope-authorization/).
+For scope setup, see [Tool Scope Authorization](../../getting-started/tool-scope-authorization/).
 
 ## Recommended Production Baseline
 

--- a/examples/authenticated-scanning/README.md
+++ b/examples/authenticated-scanning/README.md
@@ -1,0 +1,48 @@
+# Optional Form-Login Target Authentication
+
+These templates add one operator-managed form-login profile to the local
+Docker Compose stack. Use them only when an application you are authorized to
+scan requires a straightforward username/password HTML form.
+
+This is target authentication: ZAP logs in to the application. It is separate
+from the API key or JWT that Cursor uses to access MCP ZAP Server.
+
+The example assumes the target runs on the host at
+`http://host.docker.internal:8080`. It is a template, not a bundled test
+application. Copy `auth-profiles.example.yml` outside the repository and edit:
+
+- the exact origin and login URL
+- the dedicated scan username
+- the form fields' HTML `name` attributes
+- stable logged-in and logged-out indicators
+
+Keep the password in a separate host file. Add the two fully expanded absolute
+paths to the ignored root `.env` file:
+
+```dotenv
+MCP_ZAP_AUTH_PROFILES_FILE=/absolute/path/to/auth-profiles.yml
+MCP_ZAP_FORM_PASSWORD_FILE=/absolute/path/to/target-form-password
+```
+
+Then use the same three Compose files whenever this profile is enabled:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  config --quiet
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+  up -d --build --force-recreate --wait
+```
+
+`./dev.sh` does not load the optional override. Do not use it while this profile
+is enabled, because it can recreate `mcp-server` without the profile.
+
+For the complete setup, Cursor prompt, success criteria, networking cases, and
+troubleshooting, read the
+[Form-Login Target Authentication guide](https://danieltse.org/mcp-zap-server/getting-started/form-login-target-authentication/).

--- a/examples/authenticated-scanning/auth-profiles.example.yml
+++ b/examples/authenticated-scanning/auth-profiles.example.yml
@@ -1,0 +1,18 @@
+# Non-secret example for an authorized application running on the Docker host.
+# Copy this file outside the repository, then replace every target-specific value.
+mcp:
+  server:
+    auth:
+      bootstrap:
+        profiles:
+          - id: local-form-app
+            kind: form
+            allowed-origin: http://host.docker.internal:8080
+            credential-reference: file:/run/secrets/target_form_password
+            login-url: http://host.docker.internal:8080/login
+            username: dedicated-zap-scan-user
+            username-field: username
+            password-field: password
+            # Replace these with stable, server-rendered text from your application.
+            logged-in-indicator-regex: "(?i).*logout.*"
+            logged-out-indicator-regex: "(?i).*(sign in|log in).*"

--- a/examples/authenticated-scanning/docker-compose.auth-profile.yml
+++ b/examples/authenticated-scanning/docker-compose.auth-profile.yml
@@ -1,0 +1,25 @@
+# Optional override for local form-login target authentication.
+# Use it together with docker-compose.yml and docker-compose.dev.yml.
+services:
+  zap:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  mcp-server:
+    environment:
+      SPRING_CONFIG_ADDITIONAL_LOCATION: file:/app/auth-profiles.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - type: bind
+        source: ${MCP_ZAP_AUTH_PROFILES_FILE:?set MCP_ZAP_AUTH_PROFILES_FILE to an absolute file path}
+        target: /app/auth-profiles.yml
+        read_only: true
+        bind:
+          create_host_path: false
+    secrets:
+      - target_form_password
+
+secrets:
+  target_form_password:
+    file: ${MCP_ZAP_FORM_PASSWORD_FILE:?set MCP_ZAP_FORM_PASSWORD_FILE to an absolute file path}

--- a/src/test/java/mcp/server/zap/architecture/SelfServeFirstRunDocsTest.java
+++ b/src/test/java/mcp/server/zap/architecture/SelfServeFirstRunDocsTest.java
@@ -47,7 +47,7 @@ class SelfServeFirstRunDocsTest {
                 .contains("./getting-started/self-serve-first-run/")
                 .contains("SELF_SERVE_FIRST_RUN");
         assertThat(Files.readString(CLIENT_AUTH_DOC))
-                .contains("[Self-Serve First Run](./self-serve-first-run/)");
+                .contains("[Self-Serve First Run](../self-serve-first-run/)");
 
         assertThat(Files.readString(RAW_GUIDE))
                 .contains("git clone https://github.com/dtkmn/mcp-zap-server.git")


### PR DESCRIPTION
This pull request updates documentation to clarify and reorganize authentication instructions, especially distinguishing between MCP client authentication (API key or JWT) and optional target (form-login) authentication. It improves the structure and navigation of guides, adds new references to the optional form-login setup, and updates several examples and checklists for clarity and accuracy.

**Authentication Documentation Improvements:**

* Rewrote `docs/getting-started/authentication-quick-start.md` to clarify the difference between MCP client authentication (API key or JWT) and optional target form-login authentication, including updated setup steps, usage examples, and recommendations. The page is now titled "MCP Access Authentication" and includes a comparison table and troubleshooting section.
* Added and clarified references to the new "Optional Target Form-Login" guide throughout the `README.md` and linked documentation, emphasizing that target authentication is optional and separate from MCP client authentication. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R137) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L179-R188)

**Guide and Navigation Updates:**

* Updated the Astro docs navigation in `docs/astro.config.mjs` to include the new form-login target authentication guide in the correct order and improved scanning section ordering.
* In `docs/getting-started/SELF_SERVE_FIRST_RUN.md`, added a new step explaining when and why to skip target authentication for most first runs, and linked to the new form-login guide for cases where it's needed. [[1]](diffhunk://#diff-ddd6a5a9305e8ba4e304057efacb647cc508d43186f9a3ee96f309de933d4956L75-R86) [[2]](diffhunk://#diff-ddd6a5a9305e8ba4e304057efacb647cc508d43186f9a3ee96f309de933d4956L91-R102)

**Operator Runbook and Example Updates:**

* Updated the operator runbook `docs/operator/runbooks/AUTH_BOOTSTRAP_FAILURE_RUNBOOK.md` to use generic example values (e.g., `target-form`, `app.example.test`) instead of staging-specific ones, and clarified the checklist's purpose and instructions. [[1]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL107-R122) [[2]](diffhunk://#diff-339f217229f5d05396f52f572e8806499e70223f7e8dc4dc758aa8ca3923645eL133-R141)