### PR TITLE
Pin GitHub Actions to specific commit SHAs for stability and security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: "25"
           distribution: temurin
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-reports
           if-no-files-found: ignore
@@ -108,26 +108,26 @@ jobs:
     env:
       BRANCH_TAG: main
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and push main images
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,18 +30,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up JDK 25
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: "25"
           distribution: temurin
           cache: gradle
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -49,9 +49,9 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm
@@ -50,7 +50,7 @@ jobs:
       
       - name: Upload artifact
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./docs/dist
 
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           printf 'version=%s\n' "$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           printf 'publish_latest=%s\n' "$publish_latest" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -88,7 +88,7 @@ jobs:
           }
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: "25"
           distribution: temurin
@@ -138,7 +138,7 @@ jobs:
         run: ./gradlew -p examples/extensions/standalone-policy-metadata-extension clean build --scan --no-daemon --stacktrace --info
 
       - name: Archive SBOM workflow artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-${{ steps.vars.outputs.version }}
           path: build/reports/cyclonedx-direct/bom.json
@@ -168,23 +168,23 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and push release images
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -28,24 +28,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           java-version: "25"
           distribution: temurin
           cache: gradle
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
       - name: Set up Snyk CLI
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@8e119fbb6c251787721d34ba683ed48eba792766 # master
 
       - name: Require Snyk configuration
         env:
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Snyk Open Source SARIF
         if: always() && hashFiles('snyk-open-source.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: snyk-open-source.sarif
           category: snyk-open-source
@@ -102,10 +102,10 @@ jobs:
       IMAGE_REF: mcp-zap-server:snyk-scan
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Snyk CLI
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@8e119fbb6c251787721d34ba683ed48eba792766 # master
 
       - name: Require Snyk configuration
         env:
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload Snyk Container SARIF
         if: always() && hashFiles('snyk-container.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: snyk-container.sarif
           category: snyk-container
@@ -167,13 +167,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Set up Snyk CLI
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@8e119fbb6c251787721d34ba683ed48eba792766 # master
 
       - name: Require Snyk configuration
         env:
@@ -213,7 +213,7 @@ jobs:
 
       - name: Upload Snyk IaC SARIF
         if: always() && hashFiles('snyk-iac.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: snyk-iac.sarif
           category: snyk-iac

--- a/.github/workflows/zap-security-gate-juice-shop.yml
+++ b/.github/workflows/zap-security-gate-juice-shop.yml
@@ -24,10 +24,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload ZAP gate artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: zap-security-gate-juice-shop
           path: zap-artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made each guided profile's ZAP context scope immutable and origin-wide, validated login indicators before secret resolution or engine mutation, and kept credential-source metadata out of MCP caller errors.
 - Made form-login validation fail closed unless ZAP reports `likelyAuthenticated=true`, and reject terminal-dot target hosts before URL policy checks or engine dispatch.
 - Made the JVM container run as UID/GID 1000 and made the authenticated-profile Helm migration verify and deploy the exact main-commit image tag.
+- Hardened release provenance so only immutable releases from reviewed `main` history can publish, and pinned every remote GitHub Action to a verified full commit SHA.
 
 ## [0.9.1] - 2026-06-26
 

--- a/docs/releases/RELEASE_NOTES_0.10.0.md
+++ b/docs/releases/RELEASE_NOTES_0.10.0.md
@@ -69,6 +69,7 @@ The JVM image now runs as UID/GID `1000`. Existing bind mounts and mounted secre
 - Made form-login validation fail closed unless ZAP reports `likelyAuthenticated=true`.
 - Rejected terminal-dot hosts so URL policy and ZAP cannot resolve different destination identities.
 - Moved the JVM runtime image to a non-root user.
+- Hardened release provenance so only immutable releases from reviewed `main` history can publish, and pinned every remote GitHub Action to a verified full commit SHA.
 
 ## Extension API
 

--- a/src/test/java/mcp/server/zap/architecture/DockerPublishWorkflowArchitectureTest.java
+++ b/src/test/java/mcp/server/zap/architecture/DockerPublishWorkflowArchitectureTest.java
@@ -51,13 +51,13 @@ class DockerPublishWorkflowArchitectureTest {
         assertThat(steps).allSatisfy(step -> assertThat(step.has("continue-on-error")).isFalse());
 
         JsonNode resolve = stepNamed(steps, "Resolve release metadata");
-        JsonNode checkout = stepUsing(steps, "actions/checkout@v7");
+        JsonNode checkout = stepUsing(steps, "actions/checkout");
         JsonNode verify = stepNamed(steps, "Verify release tag, commit, and project version");
         JsonNode archive = stepNamed(steps, "Archive SBOM workflow artifact");
         JsonNode ghcrLogin = stepNamed(steps, "Log in to GitHub Container Registry");
         JsonNode dockerHubLogin = stepNamed(steps, "Login to Docker Hub");
         List<JsonNode> publishers = steps.stream()
-                .filter(step -> "docker/build-push-action@v7".equals(step.path("uses").asString()))
+                .filter(step -> step.path("uses").asString().startsWith("docker/build-push-action@"))
                 .toList();
         assertThat(publishers).hasSize(1);
         JsonNode publish = publishers.getFirst();
@@ -215,11 +215,11 @@ class DockerPublishWorkflowArchitectureTest {
                 .orElseThrow(() -> new AssertionError("Missing workflow step: " + name));
     }
 
-    private static JsonNode stepUsing(List<JsonNode> steps, String action) {
+    private static JsonNode stepUsing(List<JsonNode> steps, String actionRepository) {
         return steps.stream()
-                .filter(step -> action.equals(step.path("uses").asString()))
+                .filter(step -> step.path("uses").asString().startsWith(actionRepository + "@"))
                 .findFirst()
-                .orElseThrow(() -> new AssertionError("Missing workflow action: " + action));
+                .orElseThrow(() -> new AssertionError("Missing workflow action: " + actionRepository));
     }
 
     private static Map<String, String> resolveRelease(


### PR DESCRIPTION
This pull request updates all GitHub Actions in the CI/CD workflow files to use explicit commit SHAs instead of version tags. This change improves supply chain security by ensuring that workflows always use the exact, reviewed versions of actions, preventing unexpected changes from upstream action updates. Additionally, minor improvements were made to the workflow architecture tests to accommodate the new action reference format.

**GitHub Actions hardening:**

* All actions in workflow files (e.g., `actions/checkout`, `actions/setup-java`, `docker/build-push-action`, etc.) are now referenced by their full commit SHA instead of a version tag across `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/pages.yml`, `.github/workflows/release.yml`, `.github/workflows/snyk.yml`, and `.github/workflows/zap-security-gate-juice-shop.yml`. This ensures deterministic and secure builds. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL27-R30) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL85-R85) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL111-R130) [[4]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L33-R55) [[5]](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L23-R29) [[6]](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L53-R53) [[7]](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L72-R72) [[8]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R45) [[9]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L91-R91) [[10]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L141-R141) [[11]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L171-R187) [[12]](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5L31-R48) [[13]](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5L83-R83) [[14]](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5L105-R108) [[15]](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5L147-R147) [[16]](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5L170-R176) [[17]](diffhunk://#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5L216-R216) [[18]](diffhunk://#diff-aecf86c5996e59fd1796dbbf88c64336ce10fcd421df53bef6b004988e98f007L27-R30) [[19]](diffhunk://#diff-aecf86c5996e59fd1796dbbf88c64336ce10fcd421df53bef6b004988e98f007L162-R162)

**Test improvements:**

* Updated workflow architecture tests in `DockerPublishWorkflowArchitectureTest.java` to support matching actions by repository prefix rather than exact version string, making tests compatible with SHA-based action references. [[1]](diffhunk://#diff-8140ecb2513e9d26c94bad301c26a6fa46880f0fc637d604d3e376ec16a56d9dL54-R60) [[2]](diffhunk://#diff-8140ecb2513e9d26c94bad301c26a6fa46880f0fc637d604d3e376ec16a56d9dL218-R222)