### PR TITLE
Refine CodeQL workflow and enhance PolicyDryRunService validation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: ["main", "dev"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "dev"]
+    branches: ["main"]
   schedule:
     - cron: "17 3 * * 1"
 
@@ -23,9 +23,15 @@ jobs:
         include:
           - name: java
             language: java-kotlin
-            build-mode: autobuild
+            build-mode: manual
           - name: javascript
             language: javascript-typescript
+            build-mode: none
+          - name: python
+            language: python
+            build-mode: none
+          - name: actions
+            language: actions
             build-mode: none
 
     steps:
@@ -47,9 +53,11 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
-      - name: Autobuild
-        if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      - name: Build Java
+        if: matrix.language == 'java-kotlin' && matrix.build-mode == 'manual'
+        run: |
+          ./gradlew clean testClasses sampleExtensionClasses verifyExtensionApiPublication --no-daemon --stacktrace
+          ./gradlew -p examples/extensions/standalone-policy-metadata-extension clean testClasses --no-daemon --stacktrace
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/src/main/java/mcp/server/zap/core/service/policy/PolicyDryRunService.java
+++ b/src/main/java/mcp/server/zap/core/service/policy/PolicyDryRunService.java
@@ -311,7 +311,8 @@ public class PolicyDryRunService implements PolicyBundlePreviewer {
         }
 
         PolicyBundleMatch match = parseMatch(ruleNode.get("match"), prefix + ".match", errors);
-        if (id == null || decision == null || reason == null || match == null) {
+        // Description is required authoring metadata; runtime evaluation emits reason instead.
+        if (id == null || description == null || decision == null || reason == null || match == null) {
             return null;
         }
         PolicyBundleDecision decisionValue = RULE_DECISIONS.contains(decision)

--- a/src/test/java/mcp/server/zap/core/service/policy/PolicyDryRunServiceTest.java
+++ b/src/test/java/mcp/server/zap/core/service/policy/PolicyDryRunServiceTest.java
@@ -1,6 +1,8 @@
 package mcp.server.zap.core.service.policy;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -227,6 +229,28 @@ class PolicyDryRunServiceTest {
                 .anyMatch(error -> error.contains("toolName must be an exact known MCP tool or action"))
                 .anyMatch(error -> error.contains("target must be"))
                 .anyMatch(error -> error.contains("evaluatedAt must be"));
+    }
+
+    @Test
+    void dryRunRejectsRuleWithoutDescription() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode bundle = objectMapper.readTree(
+                Files.readString(Path.of("examples/policy-bundles/ci-guided-guardrails.json"))
+        );
+        ((ObjectNode) bundle.at("/spec/rules/0")).remove("description");
+
+        Map<String, Object> response = service.dryRun(
+                objectMapper.writeValueAsString(bundle),
+                "zap_attack_start",
+                "https://api.sandbox.example.com/orders",
+                "2026-06-02T01:00:00Z"
+        );
+
+        assertThat(validation(response)).containsEntry("valid", false);
+        assertThat(stringList(validation(response), "errors"))
+                .contains("bundle.spec.rules[0].description must be a non-empty string");
+        assertThat(decision(response)).containsEntry("result", "invalid");
+        assertThat(response).containsEntry("trace", List.of());
     }
 
     @Test


### PR DESCRIPTION
This pull request updates the CodeQL workflow configuration and strengthens policy rule validation logic. The most important changes are grouped below:

**CI/CD Pipeline Updates:**

* The CodeQL workflow (`.github/workflows/codeql.yml`) now only runs on the `main` branch for both push and pull request events, removing the `dev` branch from triggers.
* The CodeQL job matrix now includes `python` and `actions` languages, and switches Java analysis from `autobuild` to a custom manual build process using `gradlew` commands for more control. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L26-R35) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L50-R60)

**Policy Rule Validation Improvements:**

* The policy rule parser in `PolicyDryRunService.java` now requires the `description` field (in addition to `id`, `decision`, `reason`, and `match`) for a rule to be valid, ensuring better authoring metadata.
* A new test `dryRunRejectsRuleWithoutDescription` is added to `PolicyDryRunServiceTest.java` to verify that rules missing a description are correctly rejected with a validation error.
* Minor imports added to `PolicyDryRunServiceTest.java` to support the new test logic.