### PR TITLE
Bump gateway-core to 0.7.2 for Streamable HTTP response fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` to `0.7.2` so Streamable HTTP responses to server-initiated requests reach the downstream MCP runtime instead of being rejected as methodless requests.
+
 ## [0.10.0] - 2026-07-15
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 # Public-preview gateway-core artifact consumed by this runtime.
-gatewayCoreVersion=0.7.1
+gatewayCoreVersion=0.7.2

--- a/src/test/java/mcp/server/zap/architecture/ZapSecurityPackCoreConsumptionArchitectureTest.java
+++ b/src/test/java/mcp/server/zap/architecture/ZapSecurityPackCoreConsumptionArchitectureTest.java
@@ -68,7 +68,7 @@ class ZapSecurityPackCoreConsumptionArchitectureTest {
         String settingsFile = Files.readString(SETTINGS_GRADLE);
         String propertiesFile = Files.readString(GRADLE_PROPERTIES);
 
-        assertThat(propertiesFile).contains("gatewayCoreVersion=0.7.1");
+        assertThat(propertiesFile).contains("gatewayCoreVersion=0.7.2");
         assertThat(buildFile)
                 .contains("implementation \"io.github.dtkmn:mcp-gateway-core:${gatewayCoreVersion}\"")
                 .contains("implementation \"io.github.dtkmn:mcp-gateway-spring-webflux:${gatewayCoreVersion}\"")


### PR DESCRIPTION
This pull request updates the `mcp-gateway-core` and `mcp-gateway-spring-webflux` dependencies to version `0.7.2` to ensure that Streamable HTTP responses to server-initiated requests are properly forwarded to the downstream MCP runtime, rather than being rejected. The update is reflected in the dependency version and corresponding test assertions.

Dependency updates:

* Updated `gatewayCoreVersion` in `gradle.properties` from `0.7.1` to `0.7.2`.
* Updated test assertion in `ZapSecurityPackCoreConsumptionArchitectureTest.java` to check for `gatewayCoreVersion=0.7.2`.

Bug fixes:

* Noted in `CHANGELOG.md` that the dependency update fixes the issue where Streamable HTTP responses to server-initiated requests were being rejected as methodless requests.