### PR TITLE
Bump MCP runtime and dependencies to version 0.10.1

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dtkmn/mcp-zap-server",
   "title": "MCP ZAP Server",
   "description": "Safe, self-hosted OWASP ZAP operator for guided AI security scans and reports.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "websiteUrl": "https://danieltse.org/mcp-zap-server/",
   "repository": {
     "url": "https://github.com/dtkmn/mcp-zap-server",
@@ -22,7 +22,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/dtkmn/mcp-zap-server:v0.10.0",
+      "identifier": "ghcr.io/dtkmn/mcp-zap-server:v0.10.1",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {
@@ -106,7 +106,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/dtkmn/mcp-zap-server:v0.10.0",
+      "identifier": "docker.io/dtkmn/mcp-zap-server:v0.10.1",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-16
+
+### Changed
+- Bumped runtime, MCP server metadata, Helm chart metadata, MCP Registry package metadata, extension proof defaults, and current install examples to `0.10.1` / `v0.10.1`.
+- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` from `0.7.1` to `0.7.2`.
+- Expanded CodeQL coverage to Java, JavaScript/TypeScript, Python, and GitHub Actions, with an explicit Java build and `main`-focused triggers.
+- Aligned policy dry-run partial-rule construction with the existing required-description validation and added regression coverage for missing descriptions.
+
 ### Fixed
-- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` to `0.7.2` so Streamable HTTP responses to server-initiated requests reach the downstream MCP runtime instead of being rejected as methodless requests.
+- Restored Streamable HTTP responses to server-initiated requests so Cursor keepalive replies reach the downstream MCP runtime and complete with HTTP `202` instead of being rejected as methodless requests.
 
 ## [0.10.0] - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ API key; never put a target website password in Cursor or an MCP prompt.
 
 ## Discovery Metadata
 
-This repository includes MCP Registry metadata in [`.mcp/server.json`](./.mcp/server.json). The `v0.10.0` Docker images are labeled with the MCP server name expected by registry and catalog tooling.
+This repository includes MCP Registry metadata in [`.mcp/server.json`](./.mcp/server.json). The `v0.10.1` Docker images are labeled with the MCP server name expected by registry and catalog tooling.
 
 Docker Compose remains the easiest installation path because the MCP server is designed to operate with an OWASP ZAP sidecar and explicit auth keys. The OCI package metadata is for advanced standalone installs where OWASP ZAP is already running and reachable from the MCP container.
 
@@ -104,17 +104,16 @@ Docker Compose remains the easiest installation path because the MCP server is d
 
 ## Latest Release
 
-`v0.10.0` secures guided target authentication and refreshes the runtime:
+`v0.10.1` restores reliable Streamable HTTP keepalive handling for Cursor and other MCP clients:
 
-- operator-managed auth profiles bind credentials and login settings to one approved origin; `zap_auth_session_prepare` now accepts only `profileId` and `targetUrl`
-- form-login validation fails closed unless ZAP reports `likelyAuthenticated=true`
-- Spring Boot `4.1.0`, gateway-core and its WebFlux adapter `0.7.1`, Gradle `9.6.1`, and Spring AI retained at `2.0.0`
-- Boot-managed Testcontainers `2.0.5` with a separate Docker-backed test task before main and release image publication
-- a non-root UID/GID `1000` runtime image plus first-timer Compose and Cursor guidance for optional form-login target authentication
+- gateway-core and its WebFlux adapter `0.7.2` correctly pass client responses to server-initiated requests downstream instead of rejecting them as methodless requests
+- the normal 30-second keepalive remains enabled; Cursor responses are accepted with HTTP `202` without `invalid_mcp_request` or keepalive timeout errors
+- no MCP tool schema, authentication configuration, Helm values, or database migration changes are required from `v0.10.0`
+- Spring Boot `4.1.0`, Spring AI `2.0.0`, Gradle `9.6.1`, and Testcontainers `2.0.5` remain unchanged
 
 Read the full notes:
 
-- [Release notes](./docs/releases/RELEASE_NOTES_0.10.0.md)
+- [Release notes](./docs/releases/RELEASE_NOTES_0.10.1.md)
 - [Changelog](./CHANGELOG.md)
 - [GitHub releases](https://github.com/dtkmn/mcp-zap-server/releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,13 @@ All security vulnerabilities in this project should be reported responsibly and 
 
 ## Supported Versions
 
-| Version     | Supported                                            |
-| ----------- | ---------------------------------------------------- |
-| `>= 0.10.0` | ✅ Active development; receives security fixes       |
-| `0.9.x`     | ⚠️ Upgrade to `0.10.0` for guided-auth security fixes |
-| `0.8.x`     | ⚠️ Critical security fixes where practical           |
-| `< 0.8.0`   | ⚠️ Legacy versions; consider upgrading               |
+| Version     | Supported                                                     |
+| ----------- | ------------------------------------------------------------- |
+| `>= 0.10.1` | ✅ Active development; receives security fixes                |
+| `0.10.0`    | ⚠️ Upgrade to `0.10.1` for Streamable HTTP client compatibility |
+| `0.9.x`     | ⚠️ Upgrade to `0.10.1` for guided-auth security fixes         |
+| `0.8.x`     | ⚠️ Critical security fixes where practical                    |
+| `< 0.8.0`   | ⚠️ Legacy versions; consider upgrading                        |
 
 ## Security Features
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'mcp.server.zap'
-version = '0.10.0'
+version = '0.10.1'
 def extensionApiPublicationVersion = version.toString()
 
 java {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,24 +36,24 @@ services:
       - ${LOCAL_ZAP_WORKPLACE_FOLDER:-./zap-workplace}/zap-wrk:/zap/wrk
       - ${LOCAL_ZAP_WORKPLACE_FOLDER:-./zap-workplace}/zap-home:/home/zap/.ZAP
 
-  open-webui:
-    image: ghcr.io/open-webui/open-webui:main
-    depends_on:
-      mcp-server:
-        condition: service_started
-    ports:
-      - "${MCP_ZAP_BIND_ADDRESS:-127.0.0.1}:3000:8080"
-    environment:
-      TOOL_SERVER_CONNECTIONS: >-
-        [{"url":"http://mcp-server:7456/mcp","path":"","type":"mcp","auth_type":"none","headers":{"X-API-Key":"${MCP_API_KEY:-change-me-to-secure-random-key}"},"config":{"enable":true},"info":{"id":"zap-security","name":"ZAP Security","description":"OWASP ZAP scanning and reporting tools exposed by the local MCP server."}}]
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    volumes:
-      - open-webui:/app/backend/data
+#  open-webui:
+#    image: ghcr.io/open-webui/open-webui:main
+#    depends_on:
+#      mcp-server:
+#        condition: service_started
+#    ports:
+#      - "${MCP_ZAP_BIND_ADDRESS:-127.0.0.1}:3000:8080"
+#    environment:
+#      TOOL_SERVER_CONNECTIONS: >-
+#        [{"url":"http://mcp-server:7456/mcp","path":"","type":"mcp","auth_type":"none","headers":{"X-API-Key":"${MCP_API_KEY:-change-me-to-secure-random-key}"},"config":{"enable":true},"info":{"id":"zap-security","name":"ZAP Security","description":"OWASP ZAP scanning and reporting tools exposed by the local MCP server."}}]
+#    healthcheck:
+#      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+#      interval: 30s
+#      timeout: 10s
+#      retries: 3
+#      start_period: 30s
+#    volumes:
+#      - open-webui:/app/backend/data
 
   mcp-server:
     build:
@@ -121,5 +121,5 @@ services:
     ports:
       - "${MCP_ZAP_BIND_ADDRESS:-127.0.0.1}:3002:8080"
 
-volumes:
-  open-webui:
+#volumes:
+#  open-webui:

--- a/docs/extensions/BUILD_YOUR_OWN_EXTENSION.md
+++ b/docs/extensions/BUILD_YOUR_OWN_EXTENSION.md
@@ -120,7 +120,7 @@ plugins {
 }
 
 def extensionApiVersion = providers.gradleProperty('extensionApiVersion')
-        .orElse('0.10.0')
+        .orElse('0.10.1')
         .get()
 def extensionApiGroup = providers.gradleProperty('extensionApiGroup')
         .orElse('io.github.dtkmn')

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -6,6 +6,7 @@ GitHub Releases remains the canonical public release archive:
 
 ## Releases
 
+- [0.10.1](./RELEASE_NOTES_0.10.1.md)
 - [0.10.0](./RELEASE_NOTES_0.10.0.md)
 - [0.9.1](./RELEASE_NOTES_0.9.1.md)
 - [0.9.0](./RELEASE_NOTES_0.9.0.md)

--- a/docs/releases/RELEASE_NOTES_0.10.1.md
+++ b/docs/releases/RELEASE_NOTES_0.10.1.md
@@ -1,0 +1,51 @@
+# Release Notes - Version 0.10.1
+
+**Release Date:** July 16, 2026
+
+## Highlights
+
+- Restored reliable Streamable HTTP connections for Cursor and other MCP clients that answer server-initiated JSON-RPC requests.
+- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` from `0.7.1` to `0.7.2`.
+- Kept the normal 30-second MCP keepalive enabled and verified successful Cursor responses with HTTP `202`.
+- Preserved the `v0.10.0` tool schemas, authentication settings, Helm values, and database contract.
+
+## Fixed
+
+### Streamable HTTP client responses
+
+The Streamable HTTP MCP endpoint accepts requests, notifications, and responses on the same `POST` route. The previous gateway adapter treated every body as a request and rejected client responses because they correctly contain an `id` and `result` or `error`, but no `method`.
+
+Gateway adapter `0.7.2` distinguishes response-shaped envelopes from requests and replays them to Spring AI for session correlation. Responses to server-initiated keepalive pings now complete with HTTP `202` instead of producing `invalid_mcp_request` errors followed by keepalive timeouts. Requests that carry a `method` remain subject to the existing authorization and abuse-protection path.
+
+The corrected path preserves the original body, `Mcp-Session-Id`, custom headers, body-size limits, and the surrounding authentication filter chain.
+
+## Continuous Security Analysis
+
+CodeQL now covers Java, JavaScript/TypeScript, Python, and GitHub Actions. Java analysis uses the repository's explicit application and standalone-extension build paths, and branch triggers are focused on pull requests and pushes targeting `main`.
+
+## Maintenance
+
+Policy dry-run regression coverage now explicitly verifies the existing required-description rule, and partial-rule construction is aligned with that validation. The externally visible policy-validation contract is unchanged.
+
+## Upgrade Notes
+
+- This is a drop-in patch from `v0.10.0`; no database migration or Helm values change is required.
+- Pull the `v0.10.1` image, restart MCP ZAP Server, and reconnect clients so they establish a fresh MCP session.
+- Remove any temporary keepalive-disablement or long-interval override used to work around the `v0.10.0` behavior. The supported default remains 30 seconds.
+- API-key and JWT access authentication continue to work unchanged. Optional target form-login profiles are also unchanged.
+
+## Runtime Versions
+
+- Spring Boot `4.1.0`
+- Spring AI `2.0.0`
+- `mcp-gateway-core` and `mcp-gateway-spring-webflux` `0.7.2`
+- Gradle `9.6.1`
+- Testcontainers `2.0.5`
+
+## Extension API
+
+`mcp-zap-extension-api` remains `experimental-local`. The locally staged proof now uses version `0.10.1`; no extension API contract changed in this release.
+
+## Diff
+
+- https://github.com/dtkmn/mcp-zap-server/compare/v0.10.0...v0.10.1

--- a/docs/src/content/docs/reference/security-policy.md
+++ b/docs/src/content/docs/reference/security-policy.md
@@ -7,12 +7,13 @@ All security vulnerabilities in this project should be reported responsibly and 
 
 ## Supported Versions
 
-| Version     | Supported                                            |
-| ----------- | ---------------------------------------------------- |
-| `>= 0.10.0` | ✅ Active development; receives security fixes       |
-| `0.9.x`     | ⚠️ Upgrade to `0.10.0` for guided-auth security fixes |
-| `0.8.x`     | ⚠️ Critical security fixes where practical           |
-| `< 0.8.0`   | ⚠️ Legacy versions; consider upgrading               |
+| Version     | Supported                                                     |
+| ----------- | ------------------------------------------------------------- |
+| `>= 0.10.1` | ✅ Active development; receives security fixes                |
+| `0.10.0`    | ⚠️ Upgrade to `0.10.1` for Streamable HTTP client compatibility |
+| `0.9.x`     | ⚠️ Upgrade to `0.10.1` for guided-auth security fixes         |
+| `0.8.x`     | ⚠️ Critical security fixes where practical                    |
+| `< 0.8.0`   | ⚠️ Legacy versions; consider upgrading                        |
 
 ## Security Features
 

--- a/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
+++ b/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
@@ -225,8 +225,8 @@ networkPolicy:
 overwriting them. If `SPRING_APPLICATION_JSON` already exists, merge the profile
 object into that value; do not define the variable twice. The default ZAP NetworkPolicy
 permits DNS only, so target egress is mandatory. Private targets also require the
-deployment's explicit URL-policy approval. The chart now defaults to `v0.10.0`,
-the first release containing this profile contract. The commands below deliberately
+deployment's explicit URL-policy approval. The chart now defaults to `v0.10.1`;
+the profile contract was introduced in `v0.10.0`. The commands below deliberately
 pin the immutable `sha-<40-character commit SHA>` image produced by main CI for the
 commit being migrated. Replace the variable placeholder before running them. Do
 not use `v0.9.1` or earlier; those images do not contain the profile contract.

--- a/docs/src/content/docs/security-modes/examples.md
+++ b/docs/src/content/docs/security-modes/examples.md
@@ -75,7 +75,7 @@ MCP_CLIENT_ID=client-1
 version: '3.8'
 services:
   mcp-zap-server:
-    image: ghcr.io/dtkmn/mcp-zap-server:v0.10.0
+    image: ghcr.io/dtkmn/mcp-zap-server:v0.10.1
     environment:
       - MCP_SECURITY_MODE=api-key
       - MCP_API_KEY=${MCP_API_KEY}
@@ -145,7 +145,7 @@ JWT_REFRESH_TOKEN_EXPIRATION=604800
 version: '3.8'
 services:
   mcp-zap-server:
-    image: ghcr.io/dtkmn/mcp-zap-server:v0.10.0
+    image: ghcr.io/dtkmn/mcp-zap-server:v0.10.1
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - MCP_SECURITY_MODE=jwt

--- a/examples/extensions/standalone-policy-metadata-extension/build.gradle
+++ b/examples/extensions/standalone-policy-metadata-extension/build.gradle
@@ -11,7 +11,7 @@ java {
     }
 }
 
-def defaultExtensionApiVersion = '0.10.0'
+def defaultExtensionApiVersion = '0.10.1'
 def rootBuildFile = file('../../../build.gradle')
 if (rootBuildFile.isFile()) {
     def matcher = rootBuildFile.text =~ /(?m)^version = '([^']+)'$/

--- a/helm/mcp-zap-server/Chart.yaml
+++ b/helm/mcp-zap-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-zap-server
 description: A Helm chart for MCP ZAP Server - Model Context Protocol server for OWASP ZAP security scanning
 type: application
-version: 0.10.0
-appVersion: "v0.10.0"
+version: 0.10.1
+appVersion: "v0.10.1"
 keywords:
   - mcp
   - zap

--- a/helm/mcp-zap-server/README.md
+++ b/helm/mcp-zap-server/README.md
@@ -239,7 +239,7 @@ helm upgrade mcp-zap ./helm/mcp-zap-server \
 # Upgrade with specific image version
 helm upgrade mcp-zap ./helm/mcp-zap-server \
   --namespace mcp-zap \
-  --set mcp.image.tag=v0.10.0
+  --set mcp.image.tag=v0.10.1
 ```
 
 ## Uninstalling

--- a/llms-install.md
+++ b/llms-install.md
@@ -122,7 +122,7 @@ docker run -d \
   -e MCP_SECURITY_ENABLED=true \
   -e MCP_SECURITY_ALLOW_PLACEHOLDER_API_KEY=false \
   -e MCP_API_KEY="$MCP_API_KEY" \
-  ghcr.io/dtkmn/mcp-zap-server:v0.10.0
+  ghcr.io/dtkmn/mcp-zap-server:v0.10.1
 ```
 
 Check the MCP server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     mcp:
       server:
         name: mcp-zap-server
-        version: ${MCP_SERVER_VERSION:0.10.0}
+        version: ${MCP_SERVER_VERSION:0.10.1}
         instructions: "Use this server to interact with the ZAP API for security testing."
         protocol: streamable
         resource-change-notification: true


### PR DESCRIPTION
This pull request updates the project to version `0.10.1`, focusing on restoring reliable Streamable HTTP keepalive handling for Cursor and other MCP clients. It also bumps dependencies, improves documentation, and updates version references throughout the project. No breaking changes to schemas or configuration are introduced, making this a drop-in patch from `v0.10.0`.

**Release and Dependency Updates**
- Bumped MCP server version, Docker/OCI image tags, Helm chart version, and extension API defaults from `0.10.0` to `0.10.1` across all relevant files. [[1]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL6-R6) [[2]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL25-R25) [[3]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL109-R109) [[4]](diffhunk://#diff-0245b53be1182e16516863131af0985c26801e94a4e680aad8fcc8fd217c0a50L123-R123) [[5]](diffhunk://#diff-cafa3c8752e25713fb619e9d69f095480ad9bb4c85902b2167b7ee68aedd406dL14-R14) [[6]](diffhunk://#diff-7e4c4988cc660783a9f485fe5469aa3e8609574fbedd835b2cc28f3168c48ee7L5-R6) [[7]](diffhunk://#diff-2a7c28ecbd584ccc4d6be9c4bb436c7055c8f68bc2a13adbb9060ce367e04575L242-R242) [[8]](diffhunk://#diff-b9b42aca071016de2981c979708715cc6cd215563cb709f59abd0f66e11943efL125-R125) [[9]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dL6-R6) [[10]](diffhunk://#diff-1f1b68d3b78970528f164c01255f768dec42536a26e6474a9358b3dcfc165585L228-R229) [[11]](diffhunk://#diff-a6f36ceaec19b858b2067b0718b22592efae3ff0801eef0db3f5b30f1b0a1125L78-R78) [[12]](diffhunk://#diff-a6f36ceaec19b858b2067b0718b22592efae3ff0801eef0db3f5b30f1b0a1125L148-R148)
- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` dependencies from `0.7.1` to `0.7.2`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19) [[2]](diffhunk://#diff-7934f48b5344c5dbd4634629a7ca779a44a07dc3778c9d7313f7a0b5611d2bbeR1-R51)

**Streamable HTTP and Client Compatibility**
- Fixed Streamable HTTP endpoint to correctly handle client responses to server-initiated requests, restoring keepalive support (Cursor now receives HTTP `202` instead of errors). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R116) [[3]](diffhunk://#diff-7934f48b5344c5dbd4634629a7ca779a44a07dc3778c9d7313f7a0b5611d2bbeR1-R51)

**Documentation and Changelog**
- Added release notes for `0.10.1`, updated changelogs, and revised documentation to highlight the new version and its compatibility improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R90) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R116) [[4]](diffhunk://#diff-ab33a6fba43321fe4b387ca85ce68a1ef7517421419eae165f84c8f485233794R9) [[5]](diffhunk://#diff-7934f48b5344c5dbd4634629a7ca779a44a07dc3778c9d7313f7a0b5611d2bbeR1-R51)
- Updated security policy and support tables to reflect `0.10.1` as the actively supported version. [[1]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L8-R11) [[2]](diffhunk://#diff-d81cb84791c9d7ed3cf7afd198058792582dcc8c8157b77b81600131debd36ffL11-R14)

**Maintenance and CI**
- Expanded CodeQL coverage to include Java, JavaScript/TypeScript, Python, and GitHub Actions, and improved policy dry-run coverage and validation alignment. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R19) [[2]](diffhunk://#diff-7934f48b5344c5dbd4634629a7ca779a44a07dc3778c9d7313f7a0b5611d2bbeR1-R51)

**Other**
- Commented out the `open-webui` service in `docker-compose.yml` (and its volume), likely to streamline the default deployment. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39-R56) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L124-R125)