### PR TITLE
Refactor CI/CD workflows and enhance distroless image health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
 
-env:
-  DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  IMAGE_NAME: mcp-zap-server
-
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
@@ -41,9 +37,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --scan --no-daemon --stacktrace --info
 
-      - name: Build published container image
-        run: docker build --tag mcp-zap-server:ci .
-
       - name: Run Docker-backed integration tests
         if: >-
           github.event_name == 'workflow_dispatch' ||
@@ -65,49 +58,21 @@ jobs:
             build/reports/tests/dockerTest/**
             build/reports/problems/problems-report.html
 
-  docker-publish:
-    name: Publish main images
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]'
+  container-build:
+    name: Build main container
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-    concurrency:
-      group: docker-publish-${{ github.ref }}
-      cancel-in-progress: true
-    env:
-      BRANCH_TAG: main
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Verify Distroless runtime signature
+        run: ./scripts/verify-distroless-signature.sh
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - name: Build and push main images
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BRANCH_TAG }}
-            ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
-            ${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.BRANCH_TAG }}
-            ${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+      - name: Build main container
+        run: docker build --platform linux/amd64 --tag mcp-zap-server:main-verify .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Verify release tag, commit, and project version
         env:
           RELEASE_VERSION: ${{ steps.vars.outputs.version }}
@@ -86,6 +89,9 @@ jobs:
             echo "Release tag must be v${project_version}" >&2
             exit 1
           }
+
+      - name: Verify Distroless runtime signature
+        run: ./scripts/verify-distroless-signature.sh
 
       - name: Set up JDK 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -147,6 +153,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver-opts: image=docker.io/moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
 
       - name: Build and push release images
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` from `0.7.2` to `0.8.0`, aligned the runtime on Jackson `3.1.5`, and migrated application JSON usage and WebFlux adapter wiring from Jackson 2 to Jackson 3.
 - Updated the managed Netty runtime from `4.2.15.Final` to `4.2.16.Final`.
 - Removed the unsupported native-image deployment facade (`Dockerfile.native`, `docker-compose.prod.yml`, and `prod.sh`) and its active performance guide; supported production paths now use the JVM container image or Helm, and the retired guide URL redirects to the production checklist.
+- Kept source compilation, bytecode, and runtime on Java 25 while moving the JVM
+  image to a digest-pinned distroless Java 25 runtime. The image now uses a
+  static HTTP probe instead of `curl`, preserving Docker and Docker Compose
+  health status while Kubernetes continues to use native HTTP probes.
+- Main-branch CI now verifies the signed distroless base and builds the AMD64
+  container without publishing rolling `main` or `sha-*` tags.
+  Multi-architecture image publication occurs only from the release workflow.
 
 ## [0.10.1] - 2026-07-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM gradle:9.6.1-jdk25 AS builder
+FROM --platform=$BUILDPLATFORM gradle:9.6.1-jdk25@sha256:934a520ae0cc1f46764c2e6e1f6510d2fcdf6a7e12328b6aee34192d14f171a2 AS builder
 WORKDIR /usr/src/app
 COPY build.gradle settings.gradle gradle.properties ./
 COPY gradle ./gradle
@@ -15,20 +15,49 @@ RUN gradle bootJar -x test && \
       echo "Expected exactly one executable application JAR, found ${boot_jar_count}: ${boot_jars}" >&2; \
       exit 1; \
     fi && \
-    cp "${boot_jars}" /tmp/app.jar
+    cp "${boot_jars}" /tmp/app.jar && \
+    mkdir -p /tmp/runtime-layout/zap/wrk /tmp/runtime-layout/home/app
+
+# The signed multi-architecture runtime index is kept literal so Dependabot can
+# update its digest. This stage also supplies the canonical distroless passwd
+# and group files to the healthcheck builder. Dependabot cannot rename this
+# repository when the next Debian generation lands; that migration is manual.
+FROM gcr.io/distroless/java25-debian13:nonroot@sha256:9ccf2b8bce700d9f450523e2055afabe4d4ee795e6d69a0647a2dcd6e180e411 AS runtime-base
+
+# Build a shell-free, statically linked HTTP health probe for the target image
+# architecture. Only /out/http-healthcheck enters the runtime image.
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS healthcheck-builder
+ARG TARGETOS
+ARG TARGETARCH
+WORKDIR /src/healthcheck
+COPY tools/healthcheck/ ./
+RUN test -n "${TARGETOS}" && \
+    test -n "${TARGETARCH}" && \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
+      go build -mod=readonly -trimpath -buildvcs=false \
+      -ldflags="-s -w -buildid=" \
+      -o /out/http-healthcheck .
+
+# Preserve the named UID/GID 1000 identity from the previous image. Distroless
+# defaults to UID 65532 and otherwise reports Java user.name as "?" for UID 1000.
+COPY --from=runtime-base /etc/passwd /out/passwd
+COPY --from=runtime-base /etc/group /out/group
+RUN printf 'app:x:1000:1000:Application user:/home/app:/sbin/nologin\n' >> /out/passwd && \
+    printf 'app:x:1000:\n' >> /out/group
 
 # Runtime stage
-FROM eclipse-temurin:25-jre-alpine
+FROM runtime-base
 LABEL io.modelcontextprotocol.server.name="io.github.dtkmn/mcp-zap-server"
-RUN apk add --no-cache --upgrade curl p11-kit p11-kit-trust && \
-    addgroup -S -g 1000 app && \
-    adduser -S -D -H -u 1000 -G app app && \
-    mkdir -p /app /zap/wrk && \
-    chown -R 1000:1000 /app /zap/wrk
+ENV HOME=/home/app
+COPY --from=healthcheck-builder /out/passwd /etc/passwd
+COPY --from=healthcheck-builder /out/group /etc/group
+COPY --from=builder /tmp/runtime-layout/home/app /home/app
+COPY --chown=1000:1000 --from=builder /tmp/runtime-layout/zap/wrk /zap/wrk
 WORKDIR /app
-COPY --chown=1000:1000 --from=builder /tmp/app.jar ./app.jar
+COPY --chmod=0444 --from=builder /tmp/app.jar ./app.jar
+COPY --chmod=0555 --from=healthcheck-builder /out/http-healthcheck /usr/local/bin/http-healthcheck
 USER 1000:1000
 EXPOSE 7456
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-  CMD curl -f http://localhost:7456/actuator/health || exit 1
-ENTRYPOINT ["java", "-Dspring.ai.mcp.server.type=sync", "-jar","/app/app.jar"]
+  CMD ["/usr/local/bin/http-healthcheck", "http://127.0.0.1:7456/actuator/health"]
+ENTRYPOINT ["/usr/bin/java", "-Dspring.ai.mcp.server.type=sync", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Those scripts are the supported local happy path, not hidden magic:
 - `dev.sh` starts the Docker Compose stack with the faster JVM image.
 - `self-serve-doctor.sh` checks Docker, auth, MCP initialize, `tools/list`, guided tools, and a harmless tool call.
 
+The JVM image remains Java 25 end to end: source compilation, bytecode, and
+runtime all target Java 25. Its final runtime is distroless, so it intentionally
+contains no shell, package manager, or `curl`. A small built-in HTTP probe keeps
+the normal Docker Compose health status; `docker compose ps` still reports the
+MCP service as `(healthy)` after startup.
+
 Then open:
 
 - Open WebUI: `http://localhost:3000`
@@ -124,6 +130,9 @@ The default posture is intentionally conservative:
 - `api-key` mode is the base runtime default.
 - `none` mode is for explicit local dev/test only.
 - Docker Compose binds published ports to loopback by default.
+- The Java 25 JVM image uses a digest-pinned distroless runtime with no shell or
+  package manager; debug it through logs, metrics, and external diagnostic
+  containers rather than installing tools into the application container.
 - URL validation blocks localhost, private networks, and link-local targets by default.
 - Target authentication is optional and profiles default to an empty list. When enabled, guided auth binds an exact server-side credential reference and login settings to one approved origin; callers provide only `profileId` and `targetUrl`.
 - Public auth exchange endpoints are rate-limited.

--- a/docs/src/content/docs/getting-started/form-login-target-authentication.md
+++ b/docs/src/content/docs/getting-started/form-login-target-authentication.md
@@ -192,14 +192,29 @@ not load the override and can recreate `mcp-server` without the profile.
 ## 5. Check The Wiring Without Printing Secrets
 
 ```bash
+AUTH_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/mcp-zap-server/auth"
+test -r "$AUTH_HOME/auth-profiles.yml"
+test -r "$AUTH_HOME/target-form-password"
+test -s "$AUTH_HOME/target-form-password"
+
+MCP_CONTAINER_ID="$(
+  docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.dev.yml \
+    -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
+    ps -q mcp-server
+)"
+MCP_MOUNTS="$(docker inspect \
+  --format '{{range .Mounts}}{{println .Destination}}{{end}}' \
+  "$MCP_CONTAINER_ID")"
+printf '%s\n' "$MCP_MOUNTS" | grep -Fx /app/auth-profiles.yml
+printf '%s\n' "$MCP_MOUNTS" | grep -Fx /run/secrets/target_form_password
+
 docker compose \
   -f docker-compose.yml \
   -f docker-compose.dev.yml \
   -f examples/authenticated-scanning/docker-compose.auth-profile.yml \
-  exec -T mcp-server sh -c \
-  'test -r /app/auth-profiles.yml &&
-   test -r /run/secrets/target_form_password &&
-   test -s /run/secrets/target_form_password'
+  ps mcp-server
 
 docker compose \
   -f docker-compose.yml \
@@ -210,6 +225,13 @@ docker compose \
 
 ./bin/self-serve-doctor.sh
 ```
+
+The host checks prove that both source files are readable and the password is
+not empty. The mount inspection prints destination paths only, never secret
+contents. The MCP JVM image is Java 25 on a distroless Java 25 runtime, so it
+does not include `sh`, `curl`, or other interactive debugging tools. The
+image's built-in static HTTP probe still drives Docker Compose health status;
+the `ps` output should show the MCP service as `(healthy)`.
 
 The doctor proves MCP and ZAP connectivity. It does not prove the target login.
 Profiles are loaded when MCP Server starts, so a health check alone is not

--- a/helm/mcp-zap-server/README.md
+++ b/helm/mcp-zap-server/README.md
@@ -18,6 +18,11 @@ This chart deploys two main components in **separate pods**:
    - Lightweight (512MB-1GB RAM)
    - Auto-scaling is opt-in
 
+The MCP image remains a Java 25 application and uses a distroless Java 25
+runtime. It intentionally has no shell, `curl`, or package manager. The chart's
+startup, readiness, and liveness checks are Kubernetes-native HTTP probes; they
+do not execute commands inside the container.
+
 ## Prerequisites
 
 - Kubernetes 1.23+
@@ -286,12 +291,39 @@ kubectl describe pvc -n mcp-zap mcp-zap-zap-pvc
 ### MCP Server Cannot Connect to ZAP
 
 ```bash
-# Check if ZAP service is accessible
-kubectl exec -n mcp-zap deployment/mcp-zap-mcp -- curl http://mcp-zap-zap:8090
+# Check MCP readiness, probe failures, and application diagnostics
+kubectl get pods -n mcp-zap \
+  -l app.kubernetes.io/name=mcp-server,app.kubernetes.io/instance=mcp-zap
+kubectl describe pods -n mcp-zap \
+  -l app.kubernetes.io/name=mcp-server,app.kubernetes.io/instance=mcp-zap
+kubectl logs -n mcp-zap \
+  -l app.kubernetes.io/name=mcp-server,app.kubernetes.io/instance=mcp-zap
 
-# Verify environment variables
-kubectl exec -n mcp-zap deployment/mcp-zap-mcp -- env | grep ZAP
+# Verify the configured ZAP variable names without exposing secret values
+MCP_DEPLOYMENT="$(kubectl get deployment -n mcp-zap \
+  -l app.kubernetes.io/name=mcp-server,app.kubernetes.io/instance=mcp-zap \
+  -o jsonpath='{.items[0].metadata.name}')"
+kubectl get deployment -n mcp-zap "$MCP_DEPLOYMENT" \
+  -o jsonpath='{range .spec.template.spec.containers[?(@.name=="mcp-server")].env[*]}{.name}{"\n"}{end}' \
+  | grep '^ZAP_'
+
+# Test service DNS and HTTP reachability from an existing MCP pod
+MCP_POD="$(kubectl get pod -n mcp-zap \
+  -l app.kubernetes.io/name=mcp-server,app.kubernetes.io/instance=mcp-zap \
+  -o jsonpath='{.items[0].metadata.name}')"
+ZAP_SERVICE="$(kubectl get service -n mcp-zap \
+  -l app.kubernetes.io/name=zap-proxy,app.kubernetes.io/instance=mcp-zap \
+  -o jsonpath='{.items[0].metadata.name}')"
+kubectl exec -n mcp-zap "$MCP_POD" -c mcp-server -- \
+  /usr/local/bin/http-healthcheck "http://${ZAP_SERVICE}:8090/" \
+  && echo "ZAP service is reachable from the MCP pod"
 ```
+
+The MCP runtime is distroless and has no in-container shell, `curl`, or `env`
+executable. The last command executes only the image's built-in static HTTP
+probe; it prints a diagnostic and exits non-zero when DNS, TCP, or HTTP fails.
+If your Helm release or namespace is not `mcp-zap`, update the instance labels
+and namespace in these commands.
 
 ### Horizontal Pod Autoscaler Not Working
 

--- a/helm/mcp-zap-server/values.yaml
+++ b/helm/mcp-zap-server/values.yaml
@@ -308,6 +308,7 @@ podSecurityContext:
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
   runAsNonRoot: true
+  runAsGroup: 1000
   runAsUser: 1000
   seccompProfile:
     type: RuntimeDefault
@@ -319,6 +320,7 @@ securityContext:
     - ALL
   readOnlyRootFilesystem: false
   runAsNonRoot: true
+  runAsGroup: 1000
   runAsUser: 1000
   allowPrivilegeEscalation: false
   seccompProfile:

--- a/scripts/verify-distroless-signature.sh
+++ b/scripts/verify-distroless-signature.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dockerfile="${1:-Dockerfile}"
+distroless_image="$(
+  awk '$1 == "FROM" && $2 ~ /^gcr.io\\/distroless\\// { print $2; exit }' "${dockerfile}"
+)"
+
+cosign verify \
+  --certificate-oidc-issuer https://accounts.google.com \
+  --certificate-identity keyless@distroless.iam.gserviceaccount.com \
+  "${distroless_image}" >/dev/null

--- a/tools/healthcheck/go.mod
+++ b/tools/healthcheck/go.mod
@@ -1,3 +1,5 @@
 module github.com/dtkmn/mcp-zap-server/tools/healthcheck
 
-go 1.26.5
+go 1.26.3
+
+toolchain go1.26.5

--- a/tools/healthcheck/go.mod
+++ b/tools/healthcheck/go.mod
@@ -1,0 +1,3 @@
+module github.com/dtkmn/mcp-zap-server/tools/healthcheck
+
+go 1.26

--- a/tools/healthcheck/go.mod
+++ b/tools/healthcheck/go.mod
@@ -1,3 +1,3 @@
 module github.com/dtkmn/mcp-zap-server/tools/healthcheck
 
-go 1.26
+go 1.26.5

--- a/tools/healthcheck/main.go
+++ b/tools/healthcheck/main.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: http-healthcheck <http-url>")
+		os.Exit(1)
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   4 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	response, err := client.Get(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusBadRequest {
+		fmt.Fprintf(os.Stderr, "healthcheck failed: HTTP %d\n", response.StatusCode)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This pull request introduces a major overhaul of the container image build and runtime approach for the MCP Zap Server. The image now uses a digest-pinned distroless Java 25 runtime, removing the shell, package manager, and `curl`, and replaces them with a custom static HTTP health probe. The CI and release workflows are updated to verify the distroless base's signature and change container build/publish behavior. Documentation and Helm chart instructions are updated to reflect these changes, emphasizing new debugging and health check methods. Security context settings are also tightened for Kubernetes deployments.

**Container Image and Runtime:**

* The Docker image now uses a digest-pinned distroless Java 25 base, removing all shell utilities and `curl`; a custom static HTTP health probe (`http-healthcheck`) is built and used for health checks instead. (`Dockerfile`, `tools/healthcheck/main.go`, `tools/healthcheck/go.mod`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L18-R63) [[2]](diffhunk://#diff-ccff75cf85008be84d41b2f2e34921110952bd72794d9940230c6545edd8dc32R1-R39) [[3]](diffhunk://#diff-00cee8a8eabcfe1b6fca2908830ed8d2a132f2c96dcdac03792eaeb8d591e6d5R1-R3)
* The build process includes explicit verification of the distroless base image's signature using `cosign`, with a new script to automate this check. (`scripts/verify-distroless-signature.sh`, [scripts/verify-distroless-signature.shR1-R12](diffhunk://#diff-5be3c16770bc63ad63d696797266f3f7090a6f4619080fe2f82028e0eb1e487fR1-R12))

**CI/CD Workflow Changes:**

* The main-branch CI workflow now verifies the signed distroless base and builds (but does not publish) the AMD64 container; only the release workflow publishes multi-arch images. (`.github/workflows/ci.yml`, [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL3-L6) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL44-L46) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL68-R78)
* Both CI and release workflows install `cosign` and verify the distroless signature prior to building images. (`.github/workflows/ci.yml`, `.github/workflows/release.yml`, [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R51-R53) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R93-R95)
* The release workflow pins the Docker Buildx builder to a specific digest for reproducibility. (`.github/workflows/release.yml`, [.github/workflows/release.ymlR156-R157](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R156-R157))

**Documentation Updates:**

* The `README.md`, Helm chart docs, and getting started guides are updated to explain the distroless runtime, the absence of shell utilities, and how to use the built-in HTTP probe for health checks and diagnostics. (`README.md`, `helm/mcp-zap-server/README.md`, `docs/src/content/docs/getting-started/form-login-target-authentication.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133-R135) [[3]](diffhunk://#diff-2a7c28ecbd584ccc4d6be9c4bb436c7055c8f68bc2a13adbb9060ce367e04575R21-R25) [[4]](diffhunk://#diff-2a7c28ecbd584ccc4d6be9c4bb436c7055c8f68bc2a13adbb9060ce367e04575L289-R327) [[5]](diffhunk://#diff-1c8d1efaf75fccae7f27a7f7cdde1cf2128b18c723ea2ab8ba39c3937d1f561bR195-R217) [[6]](diffhunk://#diff-1c8d1efaf75fccae7f27a7f7cdde1cf2128b18c723ea2ab8ba39c3937d1f561bR229-R235)

**Security and Kubernetes Hardening:**

* The Kubernetes security context in Helm values is updated to explicitly set `runAsGroup: 1000` for both pod and container security contexts, aligning with the distroless image's user model. (`helm/mcp-zap-server/values.yaml`, [[1]](diffhunk://#diff-7ed16ab911d4c3b1b4b6dcfba5abb7004e3fc0d440485240ddcea7f3acf51b5bR311) [[2]](diffhunk://#diff-7ed16ab911d4c3b1b4b6dcfba5abb7004e3fc0d440485240ddcea7f3acf51b5bR323)

**Changelog:**

* The changelog documents the switch to distroless Java 25, the new health check approach, and the CI/CD changes. (`CHANGELOG.md`, [CHANGELOG.mdR14-R20](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R20))