### PR TITLE
Bump version to 0.11.0 and update related documentation

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.dtkmn/mcp-zap-server",
   "title": "MCP ZAP Server",
   "description": "Safe, self-hosted OWASP ZAP operator for guided AI security scans and reports.",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "websiteUrl": "https://danieltse.org/mcp-zap-server/",
   "repository": {
     "url": "https://github.com/dtkmn/mcp-zap-server",
@@ -22,7 +22,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/dtkmn/mcp-zap-server:v0.10.1",
+      "identifier": "ghcr.io/dtkmn/mcp-zap-server:v0.11.0",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {
@@ -106,7 +106,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/dtkmn/mcp-zap-server:v0.10.1",
+      "identifier": "docker.io/dtkmn/mcp-zap-server:v0.11.0",
       "runtimeHint": "docker",
       "runtimeArguments": [
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-27
+
 ### Changed
-- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` from `0.7.2` to `0.8.0`, aligned the runtime on Jackson `3.1.5`, and migrated application JSON usage and WebFlux adapter wiring from Jackson 2 to Jackson 3.
-- Updated the managed Netty runtime from `4.2.15.Final` to `4.2.16.Final`.
-- Removed the unsupported native-image deployment facade (`Dockerfile.native`, `docker-compose.prod.yml`, and `prod.sh`) and its active performance guide; supported production paths now use the JVM container image or Helm, and the retired guide URL redirects to the production checklist.
-- Kept source compilation, bytecode, and runtime on Java 25 while moving the JVM
-  image to a digest-pinned distroless Java 25 runtime. The image now uses a
-  static HTTP probe instead of `curl`, preserving Docker and Docker Compose
-  health status while Kubernetes continues to use native HTTP probes.
-- Main-branch CI now verifies the signed distroless base and builds the AMD64
-  container without publishing rolling `main` or `sha-*` tags.
-  Multi-architecture image publication occurs only from the release workflow.
+- Bumped runtime, MCP server metadata, Helm chart metadata, MCP Registry package metadata, extension proof defaults, and current installation examples to `0.11.0` / `v0.11.0`.
+- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` from `0.7.2` to `0.8.0` and migrated application JSON handling and WebFlux governance wiring to Jackson 3 data binding, managed through the Jackson `3.2.1` BOM.
+- Kept compilation, bytecode, and runtime on Java 25 while moving the final JVM image from Temurin Alpine to a digest-pinned distroless Java 25 Debian 13 runtime. Docker health checks now use a static HTTP probe instead of `curl`; Kubernetes continues to use native HTTP probes.
+- Updated Netty from `4.2.15.Final` to `4.2.16.Final`, PostgreSQL JDBC to `42.7.12`, Logback to `1.5.36`, and the CycloneDX plugin to `3.3.0`.
+- Pinned the active Docker Compose and standalone installation paths to OWASP ZAP `2.17.0`, matching Helm and Docker-backed integration coverage.
+- Main-branch CI now verifies and builds the AMD64 container without publishing rolling `main` or `sha-*` tags. Versioned multi-architecture image publication remains release-only.
+- Updated the documentation stack to Astro `7.1.3`, Starlight `0.41.4`, and refreshed supporting packages.
+
+### Removed
+- Removed the unsupported native-image deployment facade: `Dockerfile.native`, `docker-compose.prod.yml`, `prod.sh`, and the active native-image performance guide. Supported production paths now use the versioned JVM image or Helm, and the retired guide URL redirects to the production checklist.
+- Removed the legacy repository-only `bin/github-ci-pack-verify.sh` aggregate verifier. CI-helper behavior remains covered by Python unit tests and the live Juice Shop workflow.
+
+### Fixed
+- Aligned the authoritative tool registry with the existing guided runtime exposure of `zap_scan_history_get` and `zap_scan_history_export`.
+
+### Security
+- Pinned the container build, health-probe, runtime, and release BuildKit inputs by digest, and added Cosign verification of the upstream distroless base image in main and release workflows.
+- Hardened GitHub and GitLab security-gate image validation so malformed SHA-256 digests are rejected before workspace directories are created.
+- Made Helm explicitly run the MCP container as UID/GID `1000`.
 
 ## [0.10.1] - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ API key; never put a target website password in Cursor or an MCP prompt.
 
 ## Discovery Metadata
 
-This repository includes MCP Registry metadata in [`.mcp/server.json`](./.mcp/server.json). The `v0.10.1` Docker images are labeled with the MCP server name expected by registry and catalog tooling.
+This repository includes MCP Registry metadata in [`.mcp/server.json`](./.mcp/server.json). The `v0.11.0` Docker images are labeled with the MCP server name expected by registry and catalog tooling.
 
 Docker Compose remains the easiest installation path because the MCP server is designed to operate with an OWASP ZAP sidecar and explicit auth keys. The OCI package metadata is for advanced standalone installs where OWASP ZAP is already running and reachable from the MCP container.
 
@@ -110,16 +110,17 @@ Docker Compose remains the easiest installation path because the MCP server is d
 
 ## Latest Release
 
-`v0.10.1` restores reliable Streamable HTTP keepalive handling for Cursor and other MCP clients:
+`v0.11.0` modernizes the runtime and container supply chain without changing MCP tool names or input schemas:
 
-- gateway-core and its WebFlux adapter `0.7.2` correctly pass client responses to server-initiated requests downstream instead of rejecting them as methodless requests
-- the normal 30-second keepalive remains enabled; Cursor responses are accepted with HTTP `202` without `invalid_mcp_request` or keepalive timeout errors
-- no MCP tool schema, authentication configuration, Helm values, or database migration changes are required from `v0.10.0`
-- Spring Boot `4.1.0`, Spring AI `2.0.0`, Gradle `9.6.1`, and Testcontainers `2.0.5` remain unchanged
+- gateway-core and its WebFlux adapter move to `0.8.0`, with application data binding migrated to Jackson 3 and managed by the Jackson `3.2.1` BOM
+- the final Java 25 image is built on a Cosign-verified, digest-pinned distroless runtime with a shell-free HTTP health probe
+- the unsupported native-image deployment facade is removed; use the versioned JVM image or Helm
+- main CI no longer publishes rolling `main` or `sha-*` images; stable AMD64 and ARM64 images are published only from GitHub immutable-release events
+- no database migration or authentication configuration change is required; the container remains UID/GID `1000`, now stated explicitly in Helm
 
 Read the full notes:
 
-- [Release notes](./docs/releases/RELEASE_NOTES_0.10.1.md)
+- [Release notes](./docs/releases/RELEASE_NOTES_0.11.0.md)
 - [Changelog](./CHANGELOG.md)
 - [GitHub releases](https://github.com/dtkmn/mcp-zap-server/releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ All security vulnerabilities in this project should be reported responsibly and 
 
 | Version     | Supported                                                     |
 | ----------- | ------------------------------------------------------------- |
-| `>= 0.10.1` | ✅ Active development; receives security fixes                |
-| `0.10.0`    | ⚠️ Upgrade to `0.10.1` for Streamable HTTP client compatibility |
-| `0.9.x`     | ⚠️ Upgrade to `0.10.1` for guided-auth security fixes         |
+| `>= 0.11.0` | ✅ Active development; receives security fixes                |
+| `0.10.x`    | ⚠️ Upgrade to `0.11.0` for the current hardened runtime       |
+| `0.9.x`     | ⚠️ Upgrade to `0.11.0` for guided-auth security fixes         |
 | `0.8.x`     | ⚠️ Critical security fixes where practical                    |
 | `< 0.8.0`   | ⚠️ Legacy versions; consider upgrading                        |
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework:spring-aop'
-    implementation 'org.aspectj:aspectjweaver:1.9.25.1'
+    implementation 'org.aspectj:aspectjweaver'
     implementation 'org.flywaydb:flyway-core'
     implementation('org.zaproxy:zap-clientapi:1.17.0') {
         exclude group: 'org.jdom', module: 'jdom'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'mcp.server.zap'
-version = '0.10.1'
+version = '0.11.0'
 def extensionApiPublicationVersion = version.toString()
 
 java {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   zap:
-    image: zaproxy/zap-stable
+    image: zaproxy/zap-stable:2.17.0
     restart: always
     command:
       - zap.sh

--- a/docs/extensions/BUILD_YOUR_OWN_EXTENSION.md
+++ b/docs/extensions/BUILD_YOUR_OWN_EXTENSION.md
@@ -120,7 +120,7 @@ plugins {
 }
 
 def extensionApiVersion = providers.gradleProperty('extensionApiVersion')
-        .orElse('0.10.1')
+        .orElse('0.11.0')
         .get()
 def extensionApiGroup = providers.gradleProperty('extensionApiGroup')
         .orElse('io.github.dtkmn')

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -6,6 +6,7 @@ GitHub Releases remains the canonical public release archive:
 
 ## Releases
 
+- [0.11.0](./RELEASE_NOTES_0.11.0.md)
 - [0.10.1](./RELEASE_NOTES_0.10.1.md)
 - [0.10.0](./RELEASE_NOTES_0.10.0.md)
 - [0.9.1](./RELEASE_NOTES_0.9.1.md)

--- a/docs/releases/RELEASE_NOTES_0.11.0.md
+++ b/docs/releases/RELEASE_NOTES_0.11.0.md
@@ -1,0 +1,102 @@
+# Release Notes - Version 0.11.0
+
+**Release Date:** July 27, 2026
+
+## Highlights
+
+- Built the published JVM image on a Cosign-verified, digest-pinned distroless Java 25 runtime with a shell-free HTTP health probe.
+- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` to `0.8.0` and migrated application data binding to Jackson 3 under the `3.2.1` BOM.
+- Removed the unsupported native-image deployment path.
+- Stopped publishing rolling `main` and `sha-*` images from main CI; versioned AMD64 and ARM64 publication remains release-only.
+- Tightened GitHub and GitLab security-gate validation of image references before workspace mutation.
+
+## Upgrade Notes
+
+### Container runtime
+
+The published JVM image is now distroless. It intentionally contains no shell,
+`curl`, package manager, or general-purpose debugging utilities. Use application
+logs, Actuator endpoints, Kubernetes-native probes, or an external diagnostic
+container. The built-in `/usr/local/bin/http-healthcheck` remains available for
+bounded HTTP reachability checks, and the existing Actuator health endpoint is
+unchanged. Replace custom exec probes or hooks that call a shell or `curl`.
+
+Runtime UID/GID remains `1000`; Helm now states both values explicitly. Existing
+mounted files, secrets, and workspaces must remain readable or writable by that
+identity as appropriate.
+
+Docker Compose and the standalone installation commands now pin
+`zaproxy/zap-stable:2.17.0`, matching the Helm default and Docker-backed
+integration coverage.
+
+### Removed native-image deployment path
+
+`Dockerfile.native`, `docker-compose.prod.yml`, and `prod.sh` are removed. Deploy
+the versioned JVM image directly or through Helm. The base Compose file is still
+the easiest local path, but it is not a substitute for a hardened production
+configuration with explicit authentication, secrets, URL policy, persistence,
+and network controls.
+
+### Image publication
+
+Main CI no longer publishes `main` or `sha-<commit>` image tags. Existing tags
+may remain in registries but will not receive new builds. Pin `v0.11.0` or an
+exact release-image digest. Stable releases continue to publish AMD64 and ARM64
+images to GHCR and Docker Hub. Registry tags are still mutable references; an
+exact digest is the strongest production pin.
+
+### Repository verification helper
+
+The legacy repository-only `bin/github-ci-pack-verify.sh` aggregate verifier is
+removed. Maintainers should run the Python CI-helper unit tests for local
+behavior checks and use the Juice Shop workflow for the live end-to-end gate.
+
+### Jackson 3 migration
+
+Application JSON handling and gateway WebFlux governance now use Jackson 3 APIs
+under `tools.jackson.*`, managed by the Jackson `3.2.1` BOM. Jackson 3
+intentionally continues to use the `com.fasterxml.jackson.core:jackson-annotations`
+`2.22` artifact; that annotation coordinate does not mean the data-binding
+runtime is still Jackson 2.
+
+Custom extensions or downstream code that depend on internal Jackson 2
+implementation types must migrate and rebuild.
+
+## Compatibility
+
+- No database migration is required.
+- MCP tool names and input schemas are unchanged from `v0.10.1`.
+- API-key, JWT, guided-auth profile, and runtime-policy configuration contracts are unchanged.
+- `zap_scan_history_get` and `zap_scan_history_export` were already exposed on the guided surface; their registry metadata now matches that runtime behavior.
+- `mcp-zap-extension-api` remains experimental/local and carries no long-term binary compatibility promise. Its public API source contract is unchanged.
+
+## Security and Supply Chain
+
+- Container build, health-probe, runtime, and release BuildKit inputs are pinned by digest.
+- Main and release workflows verify the upstream distroless base signature with Cosign before building the application image.
+- GitHub and GitLab security-gate helpers reject malformed SHA-256 image digests before creating workspace directories.
+- Helm explicitly sets the MCP container to UID/GID `1000`.
+
+## Runtime and Build Versions
+
+- Java `25`
+- OWASP ZAP `2.17.0`
+- Spring Boot `4.1.0`
+- Spring AI `2.0.0`
+- `mcp-gateway-core` and `mcp-gateway-spring-webflux` `0.8.0`
+- Jackson BOM `3.2.1`
+- Netty `4.2.16.Final`
+- PostgreSQL JDBC `42.7.12`
+- Logback `1.5.36`
+- Gradle `9.6.1`
+- CycloneDX plugin `3.3.0`
+- Testcontainers `2.0.5`
+
+## Extension API
+
+`mcp-zap-extension-api` remains `experimental-local`. The locally staged proof
+now uses version `0.11.0`; the artifact is not published by the release workflow.
+
+## Diff
+
+- https://github.com/dtkmn/mcp-zap-server/compare/v0.10.1...v0.11.0

--- a/docs/src/content/docs/reference/security-policy.md
+++ b/docs/src/content/docs/reference/security-policy.md
@@ -9,9 +9,9 @@ All security vulnerabilities in this project should be reported responsibly and 
 
 | Version     | Supported                                                     |
 | ----------- | ------------------------------------------------------------- |
-| `>= 0.10.1` | ✅ Active development; receives security fixes                |
-| `0.10.0`    | ⚠️ Upgrade to `0.10.1` for Streamable HTTP client compatibility |
-| `0.9.x`     | ⚠️ Upgrade to `0.10.1` for guided-auth security fixes         |
+| `>= 0.11.0` | ✅ Active development; receives security fixes                |
+| `0.10.x`    | ⚠️ Upgrade to `0.11.0` for the current hardened runtime       |
+| `0.9.x`     | ⚠️ Upgrade to `0.11.0` for guided-auth security fixes         |
 | `0.8.x`     | ⚠️ Critical security fixes where practical                    |
 | `< 0.8.0`   | ⚠️ Legacy versions; consider upgrading                        |
 

--- a/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
+++ b/docs/src/content/docs/scanning/authenticated-scanning-best-practices.md
@@ -164,21 +164,48 @@ after secret-only rotation. The secret target must be readable, and the
 
 ### Helm
 
-Create the Kubernetes Secret from a protected file. The key becomes the environment
-variable referenced by the profile:
+Create the runtime and target-auth Kubernetes Secrets from protected files:
 
 ```bash
 export NAMESPACE=mcp-zap
+export MCP_ZAP_ZAP_API_KEY_FILE=/run/operator-secrets/zap-api-key
+export MCP_ZAP_API_KEY_FILE=/run/operator-secrets/mcp-api-key
+export MCP_ZAP_FORM_PASSWORD_FILE=/run/operator-secrets/shop-form-password
+test -s "$MCP_ZAP_ZAP_API_KEY_FILE" \
+  && test -s "$MCP_ZAP_API_KEY_FILE" \
+  && test -s "$MCP_ZAP_FORM_PASSWORD_FILE"
+
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$NAMESPACE" create secret generic mcp-zap-runtime \
+  --from-file=ZAP_API_KEY="$MCP_ZAP_ZAP_API_KEY_FILE" \
+  --from-file=MCP_API_KEY="$MCP_ZAP_API_KEY_FILE" \
+  --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n "$NAMESPACE" create secret generic mcp-zap-auth-profile \
-  --from-file=TARGET_SCAN_PASSWORD=/run/operator-secrets/shop-form-password \
+  --from-file=TARGET_SCAN_PASSWORD="$MCP_ZAP_FORM_PASSWORD_FILE" \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
+
+Each protected file must contain only the raw secret value, without a trailing
+newline.
 
 Merge this into the values used by the deployment as `auth-profile-values.yml`:
 
 ```yaml
+zap:
+  config:
+    existingSecret:
+      name: mcp-zap-runtime
+      apiKeyKey: ZAP_API_KEY
+
 mcp:
+  security:
+    existingSecret:
+      name: mcp-zap-runtime
+      apiKeyKey: MCP_API_KEY
+  zapClient:
+    existingSecret:
+      name: mcp-zap-runtime
+      apiKeyKey: ZAP_API_KEY
   env:
     - name: SPRING_APPLICATION_JSON
       value: |-
@@ -224,11 +251,11 @@ networkPolicy:
 overwriting them. If `SPRING_APPLICATION_JSON` already exists, merge the profile
 object into that value; do not define the variable twice. The default ZAP NetworkPolicy
 permits DNS only, so target egress is mandatory. Private targets also require the
-deployment's explicit URL-policy approval. The chart now defaults to `v0.10.1`;
-the profile contract was introduced in `v0.10.0`. The commands below deliberately
-pin the immutable `sha-<40-character commit SHA>` image produced by main CI for the
-commit being migrated. Replace the variable placeholder before running them. Do
-not use `v0.9.1` or earlier; those images do not contain the profile contract.
+deployment's explicit URL-policy approval. The chart now defaults to `v0.11.0`;
+the profile contract was introduced in `v0.10.0`. The commands below use the
+versioned `v0.11.0` image published from its GitHub immutable-release event.
+Main CI no longer publishes rolling `main` or `sha-*` tags. Do not use `v0.9.1`
+or earlier; those images do not contain the profile contract.
 
 The repository does not contain a `production-values.yml`. The example below
 uses only the profile values file. If you maintain another values file, add its
@@ -240,9 +267,9 @@ Render before applying, then wait for the MCP rollout:
 (
 set -euo pipefail
 : "${NAMESPACE:?set NAMESPACE}"
-MCP_ZAP_IMAGE_TAG=sha-REPLACE_WITH_FULL_MAIN_COMMIT_SHA
-[[ "$MCP_ZAP_IMAGE_TAG" =~ ^sha-[0-9a-f]{40}$ ]] || {
-  echo "MCP_ZAP_IMAGE_TAG must be the pinned full-SHA image tag from main CI" >&2
+MCP_ZAP_IMAGE_TAG=v0.11.0
+[[ "$MCP_ZAP_IMAGE_TAG" == "v0.11.0" ]] || {
+  echo "MCP_ZAP_IMAGE_TAG must be the v0.11.0 release image tag" >&2
   exit 1
 }
 

--- a/docs/src/content/docs/security-modes/examples.md
+++ b/docs/src/content/docs/security-modes/examples.md
@@ -75,7 +75,7 @@ MCP_CLIENT_ID=client-1
 version: '3.8'
 services:
   mcp-zap-server:
-    image: ghcr.io/dtkmn/mcp-zap-server:v0.10.1
+    image: ghcr.io/dtkmn/mcp-zap-server:v0.11.0
     environment:
       - MCP_SECURITY_MODE=api-key
       - MCP_API_KEY=${MCP_API_KEY}
@@ -145,7 +145,7 @@ JWT_REFRESH_TOKEN_EXPIRATION=604800
 version: '3.8'
 services:
   mcp-zap-server:
-    image: ghcr.io/dtkmn/mcp-zap-server:v0.10.1
+    image: ghcr.io/dtkmn/mcp-zap-server:v0.11.0
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - MCP_SECURITY_MODE=jwt

--- a/examples/extensions/standalone-policy-metadata-extension/README.md
+++ b/examples/extensions/standalone-policy-metadata-extension/README.md
@@ -24,7 +24,7 @@ Then build the standalone sample:
 ./gradlew -p examples/extensions/standalone-policy-metadata-extension build
 ```
 
-The sample defaults to the documented `0.10.1` API and reads the artifact from
+The sample defaults to the documented `0.11.0` API and reads the artifact from
 `build/extension-api-public-preview-publication`. The root verification task
 passes the current project version explicitly. Outside this repository, pass
 `-PextensionApiVersion=<version>` and

--- a/examples/extensions/standalone-policy-metadata-extension/build.gradle
+++ b/examples/extensions/standalone-policy-metadata-extension/build.gradle
@@ -11,7 +11,7 @@ java {
     }
 }
 
-def defaultExtensionApiVersion = '0.10.1'
+def defaultExtensionApiVersion = '0.11.0'
 def extensionApiVersion = providers.gradleProperty('extensionApiVersion').orElse(defaultExtensionApiVersion).get()
 def extensionApiGroup = providers.gradleProperty('extensionApiGroup').orElse('io.github.dtkmn').get()
 def extensionApiCoordinate = "${extensionApiGroup}:mcp-zap-extension-api:${extensionApiVersion}"

--- a/helm/mcp-zap-server/Chart.yaml
+++ b/helm/mcp-zap-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-zap-server
 description: A Helm chart for MCP ZAP Server - Model Context Protocol server for OWASP ZAP security scanning
 type: application
-version: 0.10.1
-appVersion: "v0.10.1"
+version: 0.11.0
+appVersion: "v0.11.0"
 keywords:
   - mcp
   - zap

--- a/helm/mcp-zap-server/README.md
+++ b/helm/mcp-zap-server/README.md
@@ -135,7 +135,7 @@ helm install mcp-zap ./helm/mcp-zap-server \
 See [values.yaml](values.yaml) for all available options.
 For an AWS/EKS multi-replica baseline, see [values-ha.yaml](values-ha.yaml).
 For opinionated cloud overlays, see [values-aws.yaml](values-aws.yaml) and [values-gcp.yaml](values-gcp.yaml).
-Before exposing the service broadly, run the [production checklist](../../docs/operator/PRODUCTION_CHECKLIST.md).
+Before exposing the service broadly, run the [production checklist](../../docs/src/content/docs/operations/production-checklist.md).
 
 Automation Framework note:
 
@@ -244,7 +244,7 @@ helm upgrade mcp-zap ./helm/mcp-zap-server \
 # Upgrade with specific image version
 helm upgrade mcp-zap ./helm/mcp-zap-server \
   --namespace mcp-zap \
-  --set mcp.image.tag=v0.10.1
+  --set mcp.image.tag=v0.11.0
 ```
 
 ## Uninstalling

--- a/llms-install.md
+++ b/llms-install.md
@@ -87,7 +87,7 @@ export MCP_API_KEY="$(openssl rand -hex 32)"
 docker run --rm \
   --user root \
   -v mcp-zap-wrk:/zap/wrk \
-  zaproxy/zap-stable \
+  zaproxy/zap-stable:2.17.0 \
   sh -c 'mkdir -p /zap/wrk && chown -R 1000:1000 /zap/wrk && chmod -R u+rwX,g+rwX /zap/wrk'
 ```
 
@@ -99,7 +99,7 @@ docker run -d \
   --network mcp-zap-network \
   -v mcp-zap-wrk:/zap/wrk \
   -e ZAP_API_KEY="$ZAP_API_KEY" \
-  zaproxy/zap-stable \
+  zaproxy/zap-stable:2.17.0 \
   zap.sh -daemon -host 0.0.0.0 -port 8090 \
   -config "api.key=$ZAP_API_KEY" \
   -config "api.addrs.addr.name=.*" \
@@ -122,7 +122,7 @@ docker run -d \
   -e MCP_SECURITY_ENABLED=true \
   -e MCP_SECURITY_ALLOW_PLACEHOLDER_API_KEY=false \
   -e MCP_API_KEY="$MCP_API_KEY" \
-  ghcr.io/dtkmn/mcp-zap-server:v0.10.1
+  ghcr.io/dtkmn/mcp-zap-server:v0.11.0
 ```
 
 Check the MCP server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     mcp:
       server:
         name: mcp-zap-server
-        version: ${MCP_SERVER_VERSION:0.10.1}
+        version: ${MCP_SERVER_VERSION:0.11.0}
         instructions: "Use this server to interact with the ZAP API for security testing."
         protocol: streamable
         resource-change-notification: true


### PR DESCRIPTION
This pull request releases version `0.11.0` of MCP ZAP Server, modernizing the runtime, hardening the container supply chain, and updating dependencies and documentation throughout the project. It removes the unsupported native-image deployment path, migrates to Jackson 3 for application data binding, and pins the default OWASP ZAP version. Security has been improved with stricter image verification and explicit runtime user settings. All references to the previous version (`0.10.1`) are updated to `0.11.0` in code, metadata, documentation, and examples.

**Release and Runtime Modernization**
- Bumped all runtime, metadata, Helm chart, extension API, and example references to `0.11.0` / `v0.11.0`, including in `.mcp/server.json`, Helm charts, and documentation. [[1]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL6-R6) [[2]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL25-R25) [[3]](diffhunk://#diff-007a1e3a09b793c9dff0a722730c4f0789a4f324a30424fb95943096935686bbL109-R109) [[4]](diffhunk://#diff-7e4c4988cc660783a9f485fe5469aa3e8609574fbedd835b2cc28f3168c48ee7L5-R6) [[5]](diffhunk://#diff-0245b53be1182e16516863131af0985c26801e94a4e680aad8fcc8fd217c0a50L123-R123) [[6]](diffhunk://#diff-a6f36ceaec19b858b2067b0718b22592efae3ff0801eef0db3f5b30f1b0a1125L78-R78) [[7]](diffhunk://#diff-a6f36ceaec19b858b2067b0718b22592efae3ff0801eef0db3f5b30f1b0a1125L148-R148) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R123) [[10]](diffhunk://#diff-2c9bd72fefbc2d9b36280c2cbfd2a32f33ede6666ee3d428915305613c9b44f2L27-R27) [[11]](diffhunk://#diff-cafa3c8752e25713fb619e9d69f095480ad9bb4c85902b2167b7ee68aedd406dL14-R14)
- Updated the default OWASP ZAP image to `zaproxy/zap-stable:2.17.0` in `docker-compose.yml` and documentation. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L3-R3) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)
- The JVM image is now built on a Cosign-verified, digest-pinned distroless Java 25 runtime with a shell-free HTTP health probe.

**Dependency and Build Updates**
- Updated `mcp-gateway-core` and `mcp-gateway-spring-webflux` to `0.8.0`, migrated application data binding and WebFlux governance to Jackson 3 (managed by the `3.2.1` BOM), and updated other dependencies (Netty, PostgreSQL JDBC, Logback, CycloneDX plugin). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R31) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)
- Documentation stack updated to Astro `7.1.3` and Starlight `0.41.4`.

**Security and Supply Chain Hardening**
- Pinned all container build, health-probe, runtime, and release BuildKit inputs by digest; added Cosign verification of the distroless base image in CI. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R31) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)
- Hardened image reference validation in GitHub and GitLab security-gate helpers to reject malformed SHA-256 digests before workspace creation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R31) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)
- Helm now explicitly sets the MCP container to run as UID/GID `1000`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R31) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)

**Deployment and Documentation**
- Removed the unsupported native-image deployment path and related files/guides. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R31) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)
- Updated all documentation and examples to reference the new version, runtime, and deployment practices, including new Helm secret management examples and release notes. [[1]](diffhunk://#diff-1f1b68d3b78970528f164c01255f768dec42536a26e6474a9358b3dcfc165585L167-R208) [[2]](diffhunk://#diff-1f1b68d3b78970528f164c01255f768dec42536a26e6474a9358b3dcfc165585L227-R258) [[3]](diffhunk://#diff-1f1b68d3b78970528f164c01255f768dec42536a26e6474a9358b3dcfc165585L243-R272) [[4]](diffhunk://#diff-ab33a6fba43321fe4b387ca85ce68a1ef7517421419eae165f84c8f485233794R9) [[5]](diffhunk://#diff-d81cb84791c9d7ed3cf7afd198058792582dcc8c8157b77b81600131debd36ffL12-R14) [[6]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)

**Changelog and Release Notes**
- Added comprehensive changelog and release notes for `0.11.0`, summarizing all major changes, upgrade notes, compatibility, and security improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R31) [[2]](diffhunk://#diff-806c2611664dd1b8f2d4c3d6c571d026ddfc547746d9a356c7a7559c3cb90e5eR1-R102)

This release does not change MCP tool schemas, authentication, or database migrations, but users should update to benefit from the latest runtime, security, and supply chain improvements.